### PR TITLE
base, lexer: Add tokens, lexer interface.

### DIFF
--- a/internal/lexer/interface.go
+++ b/internal/lexer/interface.go
@@ -1,0 +1,5 @@
+package lexer
+
+type Lexer interface {
+	Lex() (*Token, error)
+}

--- a/internal/lexer/token.go
+++ b/internal/lexer/token.go
@@ -1,0 +1,51 @@
+package lexer
+
+type TokenType int
+
+const (
+	EOF TokenType = iota
+	IDENTITY
+	NUMBER
+	STRING
+
+	PATH     // .
+	PIPE     // |
+	LBRACKET // [
+	RBRACKET // ]
+
+	beginOperatorSection
+	REPLACE  // :=
+	EQFILTER // ==
+	MERGE    // +
+	endOperatorSection
+)
+
+var tokens = []string{
+	EOF:      "EOF",
+	IDENTITY: "IDENTITY",
+	NUMBER:   "NUMBER",
+	STRING:   "STRING",
+
+	PATH:     "PATH",
+	PIPE:     "PIPE",
+	LBRACKET: "LBRACKET",
+	RBRACKET: "RBRACKET",
+
+	REPLACE:  "REPLACE",
+	EQFILTER: "EQFILTER",
+	MERGE:    "MERGE",
+}
+
+func (t TokenType) String() string {
+	return tokens[t]
+}
+
+type Token struct {
+	Position int
+	Type     TokenType
+	Literal  string
+}
+
+func (t TokenType) IsOperator() bool {
+	return t > beginOperatorSection && t < endOperatorSection
+}


### PR DESCRIPTION
The expressions evaluation at nmpolicy will have a lexing step where the expression string is converted into tokens will lexical meaning, here is an example:

expression
```
default-gw: routes.running.destination=="0.0.0.0/0"
```

tokens
```yaml
- pos: 0
  type: IDENTITY(1)
  literal: routes
- pos: 6
  type: PATH(4)
  literal: PATH(4)
- pos: 7
  type: IDENTITY(1)
  literal: running
- pos: 14
  type: PATH(4)
  literal: PATH(4)
- pos: 15
  type: IDENTITY(1)
  literal: destination
- pos: 26
  type: EQUALITY(10)
  literal: EQUALITY(10)
- pos: 28
  type: STRING(3)
  literal: 0.0.0.0/0
- pos: 38
  type: EOF(0)
  literal: ""
```

Also the interface for the lexer is defined here, the interface return one token at a time and should return EOF token when there is no more tokens. A user can decide to process one a at time or store them on a slice looping until EOF.


PRs using this: 
- https://github.com/nmstate/nmpolicy/pull/1
- https://github.com/nmstate/nmpolicy/pull/2