### PR TITLE
ci, actions: pin to go.mod golang version

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,7 +1,7 @@
 name: checks
 on: [push, pull_request]
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.16
 jobs:
   lint:
     name: lint


### PR DESCRIPTION
The golang version at go.mod and github actions id different let's pin
them to 1.16 since it's the version at go.mod.

Signed-off-by: Quique Llorente <ellorent@redhat.com>