### PR TITLE
base, source: Encapsulate source and error

### DIFF
--- a/nmpolicy/internal/ast/types.go
+++ b/nmpolicy/internal/ast/types.go
@@ -27,6 +27,11 @@ type Terminal struct {
 	Identity *string `json:"identity,omitempty"`
 }
 
+type Root struct {
+	Expression string
+	Node       Node
+}
+
 type Node struct {
 	Meta
 	EqFilter *TernaryOperator  `json:"eqfilter,omitempty"`

--- a/nmpolicy/internal/capture/capture.go
+++ b/nmpolicy/internal/capture/capture.go
@@ -31,15 +31,15 @@ type Capture struct {
 }
 
 type Lexer interface {
-	Lex(expression string) ([]lexer.Token, error)
+	Lex(expression string) (lexer.Result, error)
 }
 
 type Parser interface {
-	Parse([]lexer.Token) (ast.Node, error)
+	Parse(lexer.Result) (ast.Root, error)
 }
 
 type Resolver interface {
-	Resolve(astPool map[string]ast.Node, state []byte) (map[string]types.CaptureState, error)
+	Resolve(astPool map[string]ast.Root, state []byte) (map[string]types.CaptureState, error)
 }
 
 func New(leXer Lexer, parser Parser, resolver Resolver) Capture {
@@ -61,14 +61,14 @@ func (c Capture) Resolve(
 	capturesState := filterCacheBasedOnExprCaptures(capturesCache, capturesExpr)
 	capturesExpr = filterOutExprBasedOnCachedCaptures(capturesExpr, capturesCache)
 
-	astPool := map[string]ast.Node{}
+	astPool := map[string]ast.Root{}
 	for capID, capExpr := range capturesExpr {
-		tokens, err := c.lexer.Lex(capExpr)
+		lexerResult, err := c.lexer.Lex(capExpr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
 		}
 
-		astRoot, err := c.parser.Parse(tokens)
+		astRoot, err := c.parser.Parse(lexerResult)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
 		}

--- a/nmpolicy/internal/capture/capture_test.go
+++ b/nmpolicy/internal/capture/capture_test.go
@@ -200,29 +200,29 @@ type lexerStub struct {
 	failLex bool
 }
 
-func (l lexerStub) Lex(_ string) ([]lexer.Token, error) {
+func (l lexerStub) Lex(_ string) (lexer.Result, error) {
 	if l.failLex {
-		return nil, fmt.Errorf("lex failed")
+		return lexer.Result{}, fmt.Errorf("lex failed")
 	}
-	return nil, nil
+	return lexer.Result{}, nil
 }
 
 type parserStub struct {
 	failParse bool
 }
 
-func (p parserStub) Parse(_ []lexer.Token) (ast.Node, error) {
+func (p parserStub) Parse(_ lexer.Result) (ast.Root, error) {
 	if p.failParse {
-		return ast.Node{}, fmt.Errorf("parse failed")
+		return ast.Root{}, fmt.Errorf("parse failed")
 	}
-	return ast.Node{}, nil
+	return ast.Root{}, nil
 }
 
 type resolverStub struct {
 	failResolve bool
 }
 
-func (r resolverStub) Resolve(astPool map[string]ast.Node, state []byte) (map[string]types.CaptureState, error) {
+func (r resolverStub) Resolve(astPool map[string]ast.Root, state []byte) (map[string]types.CaptureState, error) {
 	if r.failResolve {
 		return nil, fmt.Errorf("resolve failed")
 	}

--- a/nmpolicy/internal/expression/error.go
+++ b/nmpolicy/internal/expression/error.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression
+
+import (
+	"fmt"
+)
+
+// Error add the Position and Snippet to the normal message error, the Snippet
+// is generated with `Decorate` function
+type Error struct {
+	position int
+	inner    error
+	snippet  string
+}
+
+// Decorate add the `Snippet` to `Error`, using the Position and error and
+// source it will compose a string with the expression and a pointer.
+func (e *Error) Decorate(expression string) *Error {
+	e.snippet = snippet(expression, e.position)
+	return e
+}
+
+// Error mark this struct as a golang error.
+func (e *Error) Error() string {
+	return e.format()
+}
+
+func (e *Error) Unwrap() error {
+	return e.inner
+}
+
+// NewError construct a nmpolicy error that wraps golang error with a position
+// on the expression where the error is ocurring
+func WrapError(err error, pos int) *Error {
+	return &Error{
+		position: pos,
+		inner:    err,
+	}
+}
+
+func (e *Error) format() string {
+	errMsg := fmt.Sprintf(
+		"%v, pos=%d",
+		e.inner,
+		e.position,
+	)
+	if e.snippet != "" {
+		errMsg = fmt.Sprintf(
+			"%s\n%s",
+			errMsg,
+			e.snippet,
+		)
+	}
+	return errMsg
+}

--- a/nmpolicy/internal/expression/error_test.go
+++ b/nmpolicy/internal/expression/error_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expression"
+)
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		err         *expression.Error
+		expectedFmt string
+	}{
+		{expression.WrapError(fmt.Errorf("test error"), 33), "test error, pos=33"},
+		{expression.WrapError(fmt.Errorf("test error"), 4).Decorate("0123456"), `test error, pos=4
+| 0123456
+| ....^`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expectedFmt, func(t *testing.T) {
+			assert.Equal(t, tt.expectedFmt, tt.err.Error())
+		})
+	}
+}

--- a/nmpolicy/internal/expression/snippet.go
+++ b/nmpolicy/internal/expression/snippet.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Snippet returns a string containing src and a pointer at pos.
+// Example of str "123456" and pos "4":
+//
+// | 123456
+// | ...^
+func snippet(expression string, pos int) string {
+	if expression == "" {
+		return ""
+	}
+
+	if pos >= len(expression) {
+		pos = len(expression) - 1
+	}
+
+	marker := strings.Builder{}
+	for i := 0; i < pos; i++ {
+		marker.WriteString(".")
+	}
+	marker.WriteString("^")
+	return fmt.Sprintf("| %s\n| %s", expression, marker.String())
+}

--- a/nmpolicy/internal/expression/snippet_test.go
+++ b/nmpolicy/internal/expression/snippet_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSource(t *testing.T) {
+	tests := []struct {
+		expression string
+		pos        int
+		snippet    string
+	}{
+		{"012345678", 5, `
+| 012345678
+| .....^`},
+		{"012345678", -3, `
+| 012345678
+| ^`},
+		{"012345678", 10, `
+| 012345678
+| ........^`},
+		{"", 10, `
+`},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("snippet of '%s' at '%d'", tt.expression, tt.pos), func(t *testing.T) {
+			snippet := "\n" + snippet(tt.expression, tt.pos)
+			assert.Equal(t, tt.snippet, snippet)
+		})
+	}
+}

--- a/nmpolicy/internal/lexer/lexer.go
+++ b/nmpolicy/internal/lexer/lexer.go
@@ -35,24 +35,27 @@ func New() *lexer {
 
 // Lex scans the input for the next token.
 // It returns a Token struct with position, type, and the literal value.
-func (l *lexer) Lex(expression string) ([]Token, error) {
+func (l *lexer) Lex(expression string) (Result, error) {
 	l.scn = scanner.New(strings.NewReader(expression))
 	// keep looping until we return a token
-	tokens := []Token{}
+	result := Result{
+		Expression: expression,
+		Tokens:     []Token{},
+	}
 	for {
 		token, err := l.lex()
 		if err != nil {
-			return nil, err
+			return result, err
 		}
 		if token == nil {
 			continue
 		}
-		tokens = append(tokens, *token)
+		result.Tokens = append(result.Tokens, *token)
 		if token.Type == EOF {
 			break
 		}
 	}
-	return tokens, nil
+	return result, nil
 }
 
 func (l *lexer) lex() (*Token, error) {

--- a/nmpolicy/internal/lexer/lexer.go
+++ b/nmpolicy/internal/lexer/lexer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expression"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/scanner"
 )
 
@@ -35,17 +36,17 @@ func New() *lexer {
 
 // Lex scans the input for the next token.
 // It returns a Token struct with position, type, and the literal value.
-func (l *lexer) Lex(expression string) (Result, error) {
-	l.scn = scanner.New(strings.NewReader(expression))
+func (l *lexer) Lex(expr string) (Result, error) {
+	l.scn = scanner.New(strings.NewReader(expr))
 	// keep looping until we return a token
 	result := Result{
-		Expression: expression,
+		Expression: expr,
 		Tokens:     []Token{},
 	}
 	for {
 		token, err := l.lex()
 		if err != nil {
-			return result, err
+			return result, expression.WrapError(err, l.scn.Position()).Decorate(result.Expression)
 		}
 		if token == nil {
 			continue

--- a/nmpolicy/internal/lexer/lexer_test.go
+++ b/nmpolicy/internal/lexer/lexer_test.go
@@ -270,12 +270,13 @@ func testLinuxBridgeAtDefaultGwScenario(t *testing.T) {
 func runTest(t *testing.T, tests []test) {
 	for _, tt := range tests {
 		t.Run(tt.expression, func(t *testing.T) {
-			obtainedTokens, obtainedErr := lexer.New().Lex(tt.expression)
+			obtainedResult, obtainedErr := lexer.New().Lex(tt.expression)
 			if tt.expected.err != "" {
 				assert.EqualError(t, obtainedErr, tt.expected.err)
 			} else {
 				assert.NoError(t, obtainedErr)
-				assert.Equal(t, tt.expected.tokens, obtainedTokens)
+				assert.Equal(t, tt.expected.tokens, obtainedResult.Tokens)
+				assert.Equal(t, tt.expression, obtainedResult.Expression)
 			}
 		})
 	}

--- a/nmpolicy/internal/lexer/lexer_test.go
+++ b/nmpolicy/internal/lexer/lexer_test.go
@@ -127,40 +127,64 @@ func testFailures(t *testing.T) {
 	t.Run("failures", func(t *testing.T) {
 		runTest(t, []test{
 			{"foo=bar", expected{
-				err: "invalid EQFILTER operation format (b is not equal char)",
+				err: `invalid EQFILTER operation format (b is not equal char), pos=4
+| foo=bar
+| ....^`,
 			}},
 			{" foo 1foo ", expected{
-				err: "invalid number format (f is not a digit)",
+				err: `invalid number format (f is not a digit), pos=6
+|  foo 1foo 
+| ......^`,
 			}},
 			{" foo -foo ", expected{
-				err: "illegal rune -",
+				err: `illegal rune -, pos=5
+|  foo -foo 
+| .....^`,
 			}},
 			{` "bar1" "foo dar`, expected{
-				err: `invalid string format (missing " terminator)`,
+				err: `invalid string format (missing " terminator), pos=15
+|  "bar1" "foo dar
+| ...............^`,
 			}},
 			{` "bar1" 'foo dar`, expected{
-				err: "invalid string format (missing ' terminator)",
+				err: `invalid string format (missing ' terminator), pos=15
+|  "bar1" 'foo dar
+| ...............^`,
 			}},
 			{"155 -44", expected{
-				err: "illegal rune -",
+				err: `illegal rune -, pos=4
+| 155 -44
+| ....^`,
 			}},
 			{"255 1,3", expected{
-				err: "invalid number format (, is not a digit)",
+				err: `invalid number format (, is not a digit), pos=5
+| 255 1,3
+| .....^`,
 			}},
 			{"355 1e3", expected{
-				err: "invalid number format (e is not a digit)",
+				err: `invalid number format (e is not a digit), pos=5
+| 355 1e3
+| .....^`,
 			}},
 			{"455 0xEA", expected{
-				err: "invalid number format (x is not a digit)",
+				err: `invalid number format (x is not a digit), pos=5
+| 455 0xEA
+| .....^`,
 			}},
 			{"555 2,3-4", expected{
-				err: "invalid number format (, is not a digit)",
+				err: `invalid number format (, is not a digit), pos=5
+| 555 2,3-4
+| .....^`,
 			}},
 			{"655 3333_444_333", expected{
-				err: "invalid number format (_ is not a digit)",
+				err: `invalid number format (_ is not a digit), pos=8
+| 655 3333_444_333
+| ........^`,
 			}},
 			{"755 33 44 -.3", expected{
-				err: "illegal rune -",
+				err: `illegal rune -, pos=10
+| 755 33 44 -.3
+| ..........^`,
 			}},
 		})
 	})

--- a/nmpolicy/internal/lexer/token.go
+++ b/nmpolicy/internal/lexer/token.go
@@ -56,6 +56,11 @@ func (t TokenType) String() string {
 	return tokens[t]
 }
 
+type Result struct {
+	Expression string
+	Tokens     []Token
+}
+
 type Token struct {
 	Position int
 	Type     TokenType

--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -34,13 +34,15 @@ func New() *Parser {
 	return &Parser{}
 }
 
-func (p *Parser) Parse(tokens []lexer.Token) (ast.Node, error) {
-	p.tokens = tokens
+func (p *Parser) Parse(lexerResult lexer.Result) (ast.Root, error) {
+	p.tokens = lexerResult.Tokens
+	root := ast.Root{Expression: lexerResult.Expression}
 	node, err := p.parse()
 	if err != nil {
-		return ast.Node{}, err
+		return root, err
 	}
-	return node, nil
+	root.Node = node
+	return root, nil
 }
 
 func (p *Parser) parse() (ast.Node, error) {

--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
-
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expression"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
 )
 
@@ -39,7 +39,7 @@ func (p *Parser) Parse(lexerResult lexer.Result) (ast.Root, error) {
 	root := ast.Root{Expression: lexerResult.Expression}
 	node, err := p.parse()
 	if err != nil {
-		return root, err
+		return root, expression.WrapError(err, p.currentToken().Position).Decorate(root.Expression)
 	}
 	root.Node = node
 	return root, nil

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -153,13 +153,13 @@ func runTest(t *testing.T, tests []test) {
 	for _, tt := range tests {
 		t.Run(description(tt), func(t *testing.T) {
 			p := parser.New()
-			obtainedRoot, obtainedErr := p.Parse(lexer.Result{Expression: "my expression", Tokens: tt.tokens})
+			obtainedRoot, obtainedErr := p.Parse(lexer.Result{Expression: tt.expression, Tokens: tt.tokens})
 			if tt.expected.err != "" {
 				assert.EqualError(t, obtainedErr, tt.expected.err)
 			} else {
 				assert.NoError(t, obtainedErr)
 				assert.Equal(t, *tt.expected.ast, obtainedRoot.Node)
-				assert.Equal(t, "my expression", obtainedRoot.Expression)
+				assert.Equal(t, tt.expression, obtainedRoot.Expression)
 			}
 		})
 	}

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -153,12 +153,13 @@ func runTest(t *testing.T, tests []test) {
 	for _, tt := range tests {
 		t.Run(description(tt), func(t *testing.T) {
 			p := parser.New()
-			obtainedAST, obtainedErr := p.Parse(tt.tokens)
+			obtainedRoot, obtainedErr := p.Parse(lexer.Result{Expression: "my expression", Tokens: tt.tokens})
 			if tt.expected.err != "" {
 				assert.EqualError(t, obtainedErr, tt.expected.err)
 			} else {
 				assert.NoError(t, obtainedErr)
-				assert.Equal(t, *tt.expected.ast, obtainedAST)
+				assert.Equal(t, *tt.expected.ast, obtainedRoot.Node)
+				assert.Equal(t, "my expression", obtainedRoot.Expression)
 			}
 		})
 	}

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -31,15 +31,15 @@ func New() Resolver {
 	return Resolver{}
 }
 
-func (r Resolver) Resolve(astPool map[string]ast.Node, state []byte) (map[string]types.CaptureState, error) {
+func (r Resolver) Resolve(astPool map[string]ast.Root, state []byte) (map[string]types.CaptureState, error) {
 	currentState := make(map[string]interface{})
 	err := yaml.Unmarshal(state, &currentState)
 	if err != nil {
 		return nil, wrapWithResolveError(err)
 	}
 	resolvedASTs := make(map[string]types.CaptureState)
-	for captureName, ast := range astPool {
-		resolvedAST, err := r.resolveAST(ast, currentState)
+	for captureName, astRoot := range astPool {
+		resolvedAST, err := r.resolveAST(astRoot.Node, currentState)
 		if err != nil {
 			return nil, wrapWithResolveError(err)
 		}

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -270,15 +270,15 @@ eqfilter:
 	})
 }
 
-func getAstPool(astYamls map[string]string) (map[string]ast.Node, error) {
-	captureASTs := make(map[string]ast.Node)
+func getAstPool(astYamls map[string]string) (map[string]ast.Root, error) {
+	captureASTs := make(map[string]ast.Root)
 	for captureName, astYaml := range astYamls {
 		obtainedAST := &ast.Node{}
 		err := yaml.Unmarshal([]byte(astYaml), obtainedAST)
 		if err != nil {
 			return nil, err
 		}
-		captureASTs[captureName] = *obtainedAST
+		captureASTs[captureName] = ast.Root{Node: *obtainedAST}
 	}
 
 	return captureASTs, nil


### PR DESCRIPTION
Encapsulate snippet generation at their own entity source, also add a
factory function to create a reader from it, so the source type is
abstracted. Added also an error that will containe position, message and
snippet.

With this two pieces it's possible to compose an user friendly error that will look like the following

```
invalid equality filter: right hand argument is not a string, pos=28
| routes.running.destination==this.is.wrong                                     
| ............................^`
```

The error is a struct with the fields `position` and `msg`  and optionalia `snippet`, this `snippet` can be filled in with `source.Snippet` function if users want to.

Close https://github.com/nmstate/nmpolicy/issues/46