### PR TITLE
ast: Implement eqfilter and path

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,6 +33,18 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     - name: Build cmd
       run: ./scripts/make.sh --build
+  unit-test:
+    name: unit test 
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Run unit tests
+      run: ./scripts/make.sh --unit-test
   integration-test:
     name: integration-test
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/nmstate/nmpolicy
 
 go 1.16
 
-require github.com/stretchr/testify v1.7.0
+require (
+	github.com/stretchr/testify v1.7.0
+	sigs.k8s.io/yaml v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -7,5 +8,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/nmpolicy/internal/ast/types.go
+++ b/nmpolicy/internal/ast/types.go
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the nmpolicy project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+package ast
+
+type Meta struct {
+	Position int `json:"pos"`
+}
+
+type TernaryOperator [3]Node
+type VariadicOperator []Node
+type Terminal struct {
+	String   *string `json:"string,omitempty"`
+	Identity *string `json:"identity,omitempty"`
+}
+
+type Node struct {
+	Meta
+	EqFilter *TernaryOperator  `json:"eqfilter,omitempty"`
+	Path     *VariadicOperator `json:"path,omitempty"`
+	Terminal
+}

--- a/nmpolicy/internal/ast/types_test.go
+++ b/nmpolicy/internal/ast/types_test.go
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the nmpolicy project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+package ast_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func strPtr(str string) *string {
+	return &str
+}
+
+func TestYAML(t *testing.T) {
+
+	astYAML := `
+pos: 1
+eqfilter: 
+- pos: 2 
+  path: 
+  - pos: 3
+    identity: currentState
+- pos: 4
+  path:
+  - pos: 5
+    identity: routes
+  - pos: 6 
+    identity: running
+  - pos: 7 
+    identity: destination
+- pos: 8
+  string: 0.0.0.0/0
+`
+
+	obtainedAST := &ast.Node{}
+	assert.NoError(t, yaml.Unmarshal([]byte(astYAML), obtainedAST))
+
+	expectedAST := &ast.Node{
+		Meta: ast.Meta{Position: 1},
+		EqFilter: &ast.TernaryOperator{
+			{Meta: ast.Meta{Position: 2}, Path: &ast.VariadicOperator{
+				{Meta: ast.Meta{Position: 3}, Terminal: ast.Terminal{Identity: strPtr("currentState")}},
+			}},
+			{Meta: ast.Meta{Position: 4}, Path: &ast.VariadicOperator{
+				{Meta: ast.Meta{Position: 5}, Terminal: ast.Terminal{Identity: strPtr("routes")}},
+				{Meta: ast.Meta{Position: 6}, Terminal: ast.Terminal{Identity: strPtr("running")}},
+				{Meta: ast.Meta{Position: 7}, Terminal: ast.Terminal{Identity: strPtr("destination")}},
+			}},
+			{Meta: ast.Meta{Position: 8}, Terminal: ast.Terminal{String: strPtr("0.0.0.0/0")}},
+		},
+	}
+	assert.Equal(t, expectedAST, obtainedAST)
+}


### PR DESCRIPTION
The communcation between the parser and the resolver is going to be done
using a Abstract Syntax Tree or AST for short, also the idea is to start
representing an expression a filter expression like
`routes.running.destination=="0.0.0.0/0"`.
    
This change add the needed types to create a tree to represent that with
the less priority operator at the top, it contains some unit test to
check the yaml annotations.
