### PR TITLE
lexer, tokens: Add types with all the tokens

### DIFF
--- a/nmpolicy/internal/lexer/token.go
+++ b/nmpolicy/internal/lexer/token.go
@@ -1,0 +1,47 @@
+package lexer
+
+type TokenType int
+
+const (
+	EOF TokenType = iota
+	IDENTITY
+	NUMBER
+	STRING
+
+	DOT  // .
+	PIPE // |
+
+	REPLACE  // :=
+	EQFILTER // ==
+	MERGE    // +
+
+	TRUE  // true
+	FALSE // false
+)
+
+var tokens = []string{
+	EOF:      "EOF",
+	IDENTITY: "IDENTITY",
+	NUMBER:   "NUMBER",
+	STRING:   "STRING",
+
+	DOT:  "DOT",
+	PIPE: "PIPE",
+
+	REPLACE:  "REPLACE",
+	EQFILTER: "EQFILTER",
+	MERGE:    "MERGE",
+
+	TRUE:  "TRUE",
+	FALSE: "FALSE",
+}
+
+func (t TokenType) String() string {
+	return tokens[t]
+}
+
+type Token struct {
+	Position int
+	Type     TokenType
+	Literal  string
+}


### PR DESCRIPTION
There is a clear picture what tokens the lexer/parser need to understand
this change add the structs and helpers to define them.

Here is a simple example of a translation from an expression to it's tokens:

expression: 
```
routes.running.destination=="0.0.0.0/0"
```

tokens:
```
{pos: 0, type: IDENTITY, literal: "routes"}
{pos: 7, type: DOT, literal: "."}
{pos: 8, type: IDENTITY, literal: "running"}
{pos: 15, type: DOT, literal: "."}
{pos: 16, type: IDENTITY, literal: "destination"}
{pos: 27, type: EQFILTER, literal: "=="}
{pos: 29, type: STRING, literal: "0.0.0.0/0"}
```