### PR TITLE
Resolver: resolving "eqfilter" AST filtering a simple string value

### DIFF
--- a/nmpolicy/internal/resolver/errors.go
+++ b/nmpolicy/internal/resolver/errors.go
@@ -2,10 +2,14 @@ package resolver
 
 import "fmt"
 
-func filterError(err error) error {
-	return fmt.Errorf("invalid filter: %v", err)
+func filterError(format string, a ...interface{}) error {
+	return fmt.Errorf("invalid filter: %v", fmt.Errorf(format, a...))
 }
 
-func pathError(err error) error {
-	return fmt.Errorf("invalid path: %v", err)
+func pathError(format string, a ...interface{}) error {
+	return fmt.Errorf("invalid path: %v", fmt.Errorf(format, a...))
+}
+
+func wrapWithResolveError(err error) error {
+	return fmt.Errorf("resolve error: %v", err)
 }

--- a/nmpolicy/internal/resolver/errors.go
+++ b/nmpolicy/internal/resolver/errors.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the nmpolicy project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
 package resolver
 
 import "fmt"

--- a/nmpolicy/internal/resolver/errors.go
+++ b/nmpolicy/internal/resolver/errors.go
@@ -1,0 +1,11 @@
+package resolver
+
+import "fmt"
+
+func filterError(err error) error {
+	return fmt.Errorf("invalid filter: %v", err)
+}
+
+func pathError(err error) error {
+	return fmt.Errorf("invalid path: %v", err)
+}

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -10,7 +10,7 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 	filtered, err := applyFuncOnPath(inputState, path, expectedNode, mapContainsValue, true)
 
 	if err != nil {
-		return nil, filterError(fmt.Errorf("error applying operation on the path : %v", err))
+		return nil, filterError("error applying operation on the path : %v", err)
 	}
 
 	if filtered == nil {
@@ -19,7 +19,7 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 
 	filteredMap, ok := filtered.(map[string]interface{})
 	if !ok {
-		return nil, filterError(fmt.Errorf("error converting filtering result to a map"))
+		return nil, filterError("error converting filtering result to a map")
 	}
 	return filteredMap, nil
 }
@@ -40,11 +40,11 @@ func isEqual(obtainedValue interface{}, desiredValue ast.Node) (bool, error) {
 func mapContainsValue(mapToFilter map[string]interface{}, filterKey string, expectedNode ast.Node) (interface{}, error) {
 	obtainedValue, ok := mapToFilter[filterKey]
 	if !ok {
-		return nil, filterError(fmt.Errorf("cannot find key %s in %v", filterKey, obtainedValue))
+		return nil, filterError("cannot find key %s in %v", filterKey, obtainedValue)
 	}
 	valueIsEqual, err := isEqual(obtainedValue, expectedNode)
 	if err != nil {
-		return nil, filterError(fmt.Errorf("error comparing the expected and obtained values : %v", err))
+		return nil, filterError("error comparing the expected and obtained values : %v", err)
 	}
 	if valueIsEqual {
 		return mapToFilter, nil

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the nmpolicy project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
 package resolver
 
 import (

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -1,0 +1,53 @@
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func filter(inputState map[string]interface{}, path ast.VariadicOperator, expectedNode ast.Node) (map[string]interface{}, error) {
+	filtered, err := applyFuncOnPath(inputState, path, expectedNode, mapContainsValue, true)
+
+	if err != nil {
+		return nil, filterError(fmt.Errorf("error applying operation on the path : %v", err))
+	}
+
+	if filtered == nil {
+		return nil, nil
+	}
+
+	filteredMap, ok := filtered.(map[string]interface{})
+	if !ok {
+		return nil, filterError(fmt.Errorf("error converting filtering result to a map"))
+	}
+	return filteredMap, nil
+}
+
+func isEqual(obtainedValue interface{}, desiredValue ast.Node) (bool, error) {
+	if desiredValue.String != nil {
+		stringToCompare, ok := obtainedValue.(string)
+		if !ok {
+			return false, fmt.Errorf("the value %v of type %T not supported,"+
+				"curretly only string values are supported", obtainedValue, obtainedValue)
+		}
+		return stringToCompare == *desiredValue.String, nil
+	}
+
+	return false, fmt.Errorf("the desired value %v is not supported. Curretly only string values are supported", desiredValue)
+}
+
+func mapContainsValue(mapToFilter map[string]interface{}, filterKey string, expectedNode ast.Node) (interface{}, error) {
+	obtainedValue, ok := mapToFilter[filterKey]
+	if !ok {
+		return nil, filterError(fmt.Errorf("cannot find key %s in %v", filterKey, obtainedValue))
+	}
+	valueIsEqual, err := isEqual(obtainedValue, expectedNode)
+	if err != nil {
+		return nil, filterError(fmt.Errorf("error comparing the expected and obtained values : %v", err))
+	}
+	if valueIsEqual {
+		return mapToFilter, nil
+	}
+	return nil, nil
+}

--- a/nmpolicy/internal/resolver/path.go
+++ b/nmpolicy/internal/resolver/path.go
@@ -1,8 +1,6 @@
 package resolver
 
 import (
-	"fmt"
-
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
 )
 
@@ -27,7 +25,7 @@ func applyFuncOnPath(inputState interface{},
 		return applyFuncOnSlice(originalSlice, path, expectedNode, funcToApply, shouldFilterSlice)
 	}
 
-	return nil, pathError(fmt.Errorf("invalid type %T for identity step '%v'", inputState, path[0]))
+	return nil, pathError("invalid type %T for identity step '%v'", inputState, path[0])
 }
 
 func applyFuncOnSlice(originalSlice []interface{},
@@ -63,7 +61,7 @@ func applyFuncOnMap(path []ast.Node,
 	shouldFilterSlice bool) (interface{}, error) {
 	currentStep := path[0]
 	if currentStep.Identity == nil {
-		return nil, pathError(fmt.Errorf("%v has unsupported fromat", currentStep))
+		return nil, pathError("%v has unsupported fromat", currentStep)
 	}
 
 	nextPath := path[1:]
@@ -71,7 +69,7 @@ func applyFuncOnMap(path []ast.Node,
 
 	value, ok := originalMap[key]
 	if !ok {
-		return nil, pathError(fmt.Errorf("cannot find key %s in %v", key, originalMap))
+		return nil, pathError("cannot find key %s in %v", key, originalMap)
 	}
 
 	adjuctedValue, err := applyFuncOnPath(value, nextPath, expectedNode, funcToApply, shouldFilterSlice)

--- a/nmpolicy/internal/resolver/path.go
+++ b/nmpolicy/internal/resolver/path.go
@@ -1,0 +1,101 @@
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func applyFuncOnPath(inputState interface{},
+	path []ast.Node,
+	expectedNode ast.Node,
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error),
+	shouldFilterSlice bool) (interface{}, error) {
+	if len(path) == 0 {
+		return inputState, nil
+	}
+	originalMap, isMap := inputState.(map[string]interface{})
+	if isMap {
+		if len(path) == 1 {
+			return applyFuncOnLastMapOnPath(path, originalMap, expectedNode, inputState, funcToApply)
+		}
+		return applyFuncOnMap(path, originalMap, expectedNode, funcToApply, shouldFilterSlice)
+	}
+
+	originalSlice, isSlice := inputState.([]interface{})
+	if isSlice {
+		return applyFuncOnSlice(originalSlice, path, expectedNode, funcToApply, shouldFilterSlice)
+	}
+
+	return nil, pathError(fmt.Errorf("invalid type %T for identity step '%v'", inputState, path[0]))
+}
+
+func applyFuncOnSlice(originalSlice []interface{},
+	path []ast.Node,
+	expectedNode ast.Node,
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error),
+	shouldFilterSlice bool) (interface{}, error) {
+	filteredSlice := []interface{}{}
+	for _, valueToCheck := range originalSlice {
+		value, err := applyFuncOnPath(valueToCheck, path, expectedNode, funcToApply, false)
+		if err != nil {
+			return nil, err
+		}
+		if value != nil {
+			filteredSlice = append(filteredSlice, valueToCheck)
+		}
+	}
+
+	if len(filteredSlice) == 0 {
+		return nil, nil
+	}
+
+	if shouldFilterSlice {
+		return filteredSlice, nil
+	}
+	return originalSlice, nil
+}
+
+func applyFuncOnMap(path []ast.Node,
+	originalMap map[string]interface{},
+	expectedNode ast.Node,
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error),
+	shouldFilterSlice bool) (interface{}, error) {
+	currentStep := path[0]
+	if currentStep.Identity == nil {
+		return nil, pathError(fmt.Errorf("%v has unsupported fromat", currentStep))
+	}
+
+	nextPath := path[1:]
+	key := *currentStep.Identity
+
+	value, ok := originalMap[key]
+	if !ok {
+		return nil, pathError(fmt.Errorf("cannot find key %s in %v", key, originalMap))
+	}
+
+	adjuctedValue, err := applyFuncOnPath(value, nextPath, expectedNode, funcToApply, shouldFilterSlice)
+	if err != nil {
+		return nil, err
+	}
+	if adjuctedValue != nil {
+		return map[string]interface{}{key: adjuctedValue}, nil
+	}
+	return nil, nil
+}
+
+func applyFuncOnLastMapOnPath(path []ast.Node,
+	originalMap map[string]interface{},
+	expectedNode ast.Node,
+	inputState interface{},
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error)) (interface{}, error) {
+	if funcToApply != nil {
+		key := *path[0].Identity
+		outputState, err := funcToApply(originalMap, key, expectedNode)
+		if err != nil {
+			return nil, err
+		}
+		return outputState, nil
+	}
+	return inputState, nil
+}

--- a/nmpolicy/internal/resolver/path.go
+++ b/nmpolicy/internal/resolver/path.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the nmpolicy project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
 package resolver
 
 import (

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -20,6 +20,10 @@
 package resolver
 
 import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
 	"github.com/nmstate/nmpolicy/nmpolicy/types"
 )
@@ -31,5 +35,66 @@ func New() Resolver {
 }
 
 func (r Resolver) Resolve(astPool map[string]ast.Node, state []byte) (map[string]types.CaptureState, error) {
-	return nil, nil
+	currentState := make(map[string]interface{})
+	err := yaml.Unmarshal(state, &currentState)
+	if err != nil {
+		return nil, wrapWithResolveError(err)
+	}
+	resolvedASTs := make(map[string]types.CaptureState)
+	for captureName, ast := range astPool {
+		resolvedAST, err := r.resolveAST(ast, currentState)
+		if err != nil {
+			return nil, wrapWithResolveError(err)
+		}
+		rawAST, err := yaml.Marshal(resolvedAST)
+		if err != nil {
+			return nil, wrapWithResolveError(err)
+		}
+		resolvedASTs[captureName] = types.CaptureState{State: rawAST, MetaInfo: types.MetaInfo{}}
+	}
+	return resolvedASTs, nil
+}
+
+func (r Resolver) resolveAST(captureAST ast.Node, currentState map[string]interface{}) (map[string]interface{}, error) {
+	if captureAST.EqFilter != nil {
+		inputSource, err := r.resolveInputSource(captureAST.EqFilter[0], currentState)
+		if err != nil {
+			return nil, err
+		}
+
+		path, err := r.resolvePath(captureAST.EqFilter[1])
+		if err != nil {
+			return nil, err
+		}
+		filteredValue, err := r.resolveFilteredValue(captureAST.EqFilter[2])
+		if err != nil {
+			return nil, err
+		}
+
+		return filter(inputSource, *path, *filteredValue)
+	}
+	return nil, fmt.Errorf("root node has unsupported operation : %v", captureAST)
+}
+
+func (r Resolver) resolveInputSource(inputSourceNode ast.Node, currentState map[string]interface{}) (map[string]interface{}, error) {
+	if ast.CurrentStateIdentity().DeepEqual(inputSourceNode.Terminal) {
+		return currentState, nil
+	}
+
+	return nil, fmt.Errorf("not supported input source %v. Only the current state is supported", inputSourceNode)
+}
+
+func (r Resolver) resolvePath(pathNode ast.Node) (*ast.VariadicOperator, error) {
+	if pathNode.Path == nil {
+		return nil, fmt.Errorf("invalid path type %T", pathNode)
+	}
+
+	return pathNode.Path, nil
+}
+
+func (r Resolver) resolveFilteredValue(filteredValueNode ast.Node) (*ast.Node, error) {
+	if filteredValueNode.String == nil {
+		return nil, fmt.Errorf("not supported filtered value %v. Only string is supported", filteredValueNode)
+	}
+	return &filteredValueNode, nil
 }

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -1,0 +1,264 @@
+package resolver
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	yaml "sigs.k8s.io/yaml"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+var sourceYAML string = `
+routes:
+  running:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+  - destination: 1.1.1.0/24
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+  - destination: 1.1.1.0/24
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 10.244.0.1
+        prefix-length: 24
+      - ip: 169.254.1.0
+        prefix-length: 16
+      dhcp: false
+      enabled: true
+  - name: eth2
+    type: ethernet
+    state: down
+    ipv4:
+      address:
+      - ip: 1.2.3.4
+        prefix-length: 24
+      dhcp: false
+      enabled: false
+`
+
+type test struct {
+	astYamls      map[string]string
+	expectedYamls map[string]string
+	err           string
+}
+
+func runTest(t *testing.T, testToRun test) {
+	astPool, err := getAstPool(testToRun.astYamls)
+	assert.NoError(t, err)
+	resultStates, err := New().Resolve(astPool, []byte(sourceYAML))
+	if testToRun.err == "" {
+		assert.NoError(t, err)
+		expectedState := make(map[string]interface{})
+		actualState := make(map[string]interface{})
+		for captureName, expectedYaml := range testToRun.expectedYamls {
+			assert.NoError(t, yaml.Unmarshal([]byte(expectedYaml), &expectedState))
+			assert.NoError(t, yaml.Unmarshal(resultStates[captureName].State, &actualState))
+			assert.Equal(t, expectedState, actualState)
+		}
+	} else {
+		assert.Error(t, err)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	t.Run("Resolve Filter", func(t *testing.T) {
+		testFilterMapListOnSecondPathIdentity(t)
+		testFilterMapListOnFirstPathIdentity(t)
+		testFilterList(t)
+		testFilterInvalidTypeOnPath(t)
+		testFilterInvalidPath(t)
+	})
+}
+
+func testFilterMapListOnSecondPathIdentity(t *testing.T) {
+	t.Run("Filter map, list on second path identity", func(t *testing.T) {
+		testToRun := test{
+			astYamls: map[string]string{
+				"default-gw": `
+pos: 1
+eqfilter:
+- pos: 2
+  identity: currentState
+- pos: 3
+  path:
+  - pos: 4
+    identity: routes
+  - pos: 5
+    identity: running
+  - pos: 6
+    identity: destination
+- pos: 7
+  string: 0.0.0.0/0
+`},
+
+			expectedYamls: map[string]string{
+				"default-gw": `
+routes:
+ running:
+ - destination: 0.0.0.0/0
+   next-hop-address: 192.168.100.1
+   next-hop-interface: eth1
+   table-id: 254
+`},
+		}
+		runTest(t, testToRun)
+	})
+}
+
+func testFilterMapListOnFirstPathIdentity(t *testing.T) {
+	t.Run("Filter map, list on first path identity", func(t *testing.T) {
+		testToRun := test{
+			astYamls: map[string]string{
+				"up-interfaces": `
+pos: 1
+eqfilter:
+- pos: 2
+  identity: currentState
+- pos: 3
+  path:
+  - pos: 4
+    identity: interfaces
+  - pos: 5
+    identity: state
+- pos: 6
+  string: down
+`},
+			expectedYamls: map[string]string{
+				"up-interfaces": `
+interfaces:
+  - name: eth2
+    type: ethernet
+    state: down
+    ipv4:
+      address:
+      - ip: 1.2.3.4
+        prefix-length: 24
+      dhcp: false
+      enabled: false
+`},
+		}
+		runTest(t, testToRun)
+	})
+}
+
+func testFilterList(t *testing.T) {
+	t.Run("Filter list", func(t *testing.T) {
+		testToRun := test{
+			astYamls: map[string]string{
+				"specific-ipv4": `
+pos: 1
+eqfilter:
+- pos: 2
+  identity: currentState
+- pos: 3
+  path:
+  - pos: 4
+    identity: interfaces
+  - pos: 5
+    identity: ipv4
+  - pos: 6
+    identity: address
+  - pos: 7
+    identity: ip
+- pos: 8
+  string: 10.244.0.1
+`},
+			expectedYamls: map[string]string{
+				"specific-ipv4": `
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 10.244.0.1
+        prefix-length: 24
+      - ip: 169.254.1.0
+        prefix-length: 16
+      dhcp: false
+      enabled: true
+`},
+		}
+		runTest(t, testToRun)
+	})
+}
+
+func testFilterInvalidTypeOnPath(t *testing.T) {
+	t.Run("Filter invalid type on path", func(t *testing.T) {
+		testToRun := test{
+			astYamls: map[string]string{
+				"invalid-path-type": `
+pos: 1
+eqfilter:
+- pos: 2
+  identity: currentState
+- pos: 3
+  path:
+  - pos: 4
+    identity: interfaces
+  - pos: 5
+    identity: ipv4
+  - pos: 6
+    identity: address
+- pos: 7
+  string: 10.244.0.1
+`},
+			err: "invalid type on path",
+		}
+		runTest(t, testToRun)
+	})
+}
+
+func testFilterInvalidPath(t *testing.T) {
+	t.Run("Filter invalid path", func(t *testing.T) {
+		testToRun := test{
+			astYamls: map[string]string{
+				"invalid-path-identity": `
+pos: 1
+eqfilter:
+- pos: 2
+  identity: currentState
+- pos: 3
+  path:
+  - pos: 4
+    identity: interfaces
+  - pos: 5
+    identity: name-invalid-path
+- pos: 6
+  string: eth0
+`},
+			err: "invalid path",
+		}
+		runTest(t, testToRun)
+	})
+}
+
+func getAstPool(astYamls map[string]string) (map[string]ast.Node, error) {
+	captureASTs := make(map[string]ast.Node)
+	for captureName, astYaml := range astYamls {
+		obtainedAST := &ast.Node{}
+		err := yaml.Unmarshal([]byte(astYaml), obtainedAST)
+		if err != nil {
+			return nil, err
+		}
+		captureASTs[captureName] = *obtainedAST
+	}
+
+	return captureASTs, nil
+}

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the nmpolicy project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
 package resolver
 
 import (

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -55,12 +55,22 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 		// TODO: Resolve/expend the desired state.
 	}
 
+	timestamp := time.Now().UTC()
+	timestampCapturesState(capturesState, timestamp)
 	return types.GeneratedState{
 		Cache:        types.CachedState{Capture: capturesState},
 		DesiredState: desiredState,
 		MetaInfo: types.MetaInfo{
 			Version:   "0",
-			TimeStamp: time.Now().UTC(),
+			TimeStamp: timestamp,
 		},
 	}, nil
+}
+
+func timestampCapturesState(capturesState map[string]types.CaptureState, timeStamp time.Time) {
+	for _, captureState := range capturesState {
+		if captureState.MetaInfo.TimeStamp.IsZero() {
+			captureState.MetaInfo.TimeStamp = timeStamp
+		}
+	}
 }

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -76,8 +76,9 @@ func testPolicyWithCachedCapturesAndNoDesiredStateRef(t *testing.T) {
 			DesiredState: stateData,
 		}
 
+		captureTime := time.Now().Add(-5 * time.Minute).UTC()
 		cacheState := types.CachedState{
-			Capture: map[string]types.CaptureState{capID0: {State: []byte("some captured state")}},
+			Capture: map[string]types.CaptureState{capID0: {State: []byte("some captured state"), MetaInfo: types.MetaInfo{TimeStamp: captureTime}}},
 		}
 		s, err := nmpolicy.GenerateState(
 			policySpec,
@@ -90,6 +91,7 @@ func testPolicyWithCachedCapturesAndNoDesiredStateRef(t *testing.T) {
 			DesiredState: stateData,
 			MetaInfo:     types.MetaInfo{Version: "0"},
 		}
+		assert.NotEqual(t, s.MetaInfo.TimeStamp, expectedState.Cache.Capture[capID0].MetaInfo.TimeStamp)
 		assert.Equal(t, expectedState, resetTimeStamp(s))
 	})
 }


### PR DESCRIPTION
The PR introduces initial implementation to resolve an AST.
The current implementation supports only "eqfilter" operation as the root of the AST.
Only simple (not regext) strings can be filtered.

This PR is inspired by - https://github.com/nmstate/nmpolicy/pull/4/commits/ee26a0bd9fb784a14e5c9d6ae538ede8455ac890

Depends on https://github.com/nmstate/nmpolicy/pull/20