### PR TITLE
lint, test: Disable dupl and func len linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,18 +85,9 @@ linters:
     - varcheck
     - whitespace
 
-  # don't enable:
-  # - asciicheck
-  # - scopelint
-  # - gochecknoglobals
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - interfacer
-  # - maligned
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - revive
-  # - wsl
+issues:                                                                         
+  exclude-rules:                                                                
+    - path: _test.go                                                            
+      linters:                                                                  
+        - funlen                                                                
+        - dupl               


### PR DESCRIPTION
At golang test files is common to have a test function with all the
table tests there so is going to be bigger that 100 lines of code and
also we are going to have look that looks duplicate since they are very
declarative. This change disable those linters for _test.go files.

Signed-off-by: Quique Llorente <ellorent@redhat.com>