### PR TITLE
lint, license: Add linter for license header

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,3 +1,19 @@
+# Copyright 2021 The NMPolicy Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 name: checks
 on: [push, pull_request]
 env:
@@ -19,6 +35,8 @@ jobs:
           CGO_ENABLED: 0
         with:
           version: v1.42.1
+      - name: license headers 
+        run: ./scripts/make.sh --headers=check
   build:
     name: build
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,19 @@
+# Copyright 2021 The NMPolicy Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 linters-settings:
   dupl:
     threshold: 100

--- a/cmd/nmpolicy/main.go
+++ b/cmd/nmpolicy/main.go
@@ -1,3 +1,18 @@
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package main
 
 import "fmt"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,17 @@
+# Copyright 2021 The NMPolicy Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 theme: jekyll-theme-hacker

--- a/nmpolicy/internal/ast/equal.go
+++ b/nmpolicy/internal/ast/equal.go
@@ -1,3 +1,18 @@
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package ast
 
 func deepEqualStringPtr(lhs, rhs *string) bool {

--- a/nmpolicy/internal/ast/equal_test.go
+++ b/nmpolicy/internal/ast/equal_test.go
@@ -1,3 +1,18 @@
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package ast_test
 
 import (

--- a/nmpolicy/internal/ast/types.go
+++ b/nmpolicy/internal/ast/types.go
@@ -1,21 +1,18 @@
-/*
- * This file is part of the nmpolicy project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Copyright 2021 Red Hat, Inc.
- *
- */
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package ast
 
 type Meta struct {

--- a/nmpolicy/internal/ast/types_test.go
+++ b/nmpolicy/internal/ast/types_test.go
@@ -1,21 +1,18 @@
-/*
- * This file is part of the nmpolicy project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Copyright 2021 Red Hat, Inc.
- *
- */
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package ast_test
 
 import (

--- a/nmpolicy/internal/ast/values.go
+++ b/nmpolicy/internal/ast/values.go
@@ -1,3 +1,18 @@
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package ast
 
 func CurrentStateIdentity() Terminal {

--- a/nmpolicy/internal/lexer/token.go
+++ b/nmpolicy/internal/lexer/token.go
@@ -1,3 +1,18 @@
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package lexer
 
 type TokenType int

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -1,21 +1,17 @@
-/*
- * This file is part of the nmpolicy project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Copyright 2021 Red Hat, Inc.
- *
- */
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 package nmpolicy
 

--- a/nmpolicy/types.go
+++ b/nmpolicy/types.go
@@ -1,21 +1,17 @@
-/*
- * This file is part of the nmpolicy project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Copyright 2021 Red Hat, Inc.
- *
- */
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 package nmpolicy
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# Copyright 2021 The NMPolicy Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 
 set -o errexit -o nounset -o pipefail
 

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -1,15 +1,32 @@
-#!/usr/bin/env bash
+# Copyright 2021 The NMPolicy Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 set -e
 
 options=$(getopt --options "" \
-    --long build,lint,unit-test,integration-test,help\
+    --long build,headers:,lint,unit-test,integration-test,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
     case "$1" in
     --build)
         OPT_BUILD=1
+        ;;
+    --headers)
+        OPT_HEADERS=$2
         ;;
     --lint)
         OPT_LINT=1
@@ -22,7 +39,7 @@ while true; do
         ;;
     --help)
         set +x
-        echo "$0 [--build] [--lint] [--unit-test] [--integration-test]"
+        echo "$0 [--build] [--headers=[fix|check]] [--lint] [--unit-test] [--integration-test]"
         exit
         ;;
     --)
@@ -33,11 +50,12 @@ while true; do
     shift
 done
 
-if [ -z "${OPT_BUILD}" ] && [ -z "${OPT_LINT}" ] && [ -z "${OPT_UTEST}" ] && [ -z "${OPT_ITEST}" ]; then
+if [ -z "${OPT_BUILD}" ] && [ -z "${OPT_LINT}" ] && [ -z "${OPT_UTEST}" ] && [ -z "${OPT_ITEST}" ] && [ -z "${OPT_HEADERS}"]; then
     OPT_BUILD=1
     OPT_LINT=1
     OPT_UTEST=1
     OPT_ITEST=1
+    OPT_HEADERS=check
 fi
 
 if [ -n "${OPT_BUILD}" ]; then
@@ -50,6 +68,20 @@ if [ -n "${OPT_LINT}" ]; then
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
     fi
     golangci-lint run
+fi
+
+if [ -n "${OPT_HEADERS}" ]; then
+    if [ ! -f $(go env GOPATH)/bin/addlicense ]; then
+        (
+           pushd ~
+           go install github.com/google/addlicense@latest
+           popd
+        )
+    fi
+    if [ "${OPT_HEADERS}" == "check" ]; then
+        args=-check
+    fi
+    addlicense $args  -c "The NMPolicy Authors." .
 fi
 
 if [ -n "${OPT_UTEST}" ]; then

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -1,21 +1,17 @@
-/*
- * This file is part of the nmpolicy project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Copyright 2021 Red Hat, Inc.
- *
- */
+// Copyright 2021 The NMPolicy Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 package tests
 


### PR DESCRIPTION
To ensure that the golang code has the proper license header in place
this change add a linter that check that.

The change also add the missing headers and modify the ones that does
not follow the linter.