### PR TITLE
test, integration: Harcoded eq filter test

### DIFF
--- a/nmpolicy/internal/lexer/lexer.go
+++ b/nmpolicy/internal/lexer/lexer.go
@@ -26,5 +26,17 @@ func New() Lexer {
 }
 
 func (l Lexer) Lex(expression string) ([]Token, error) {
+	if expression == `routes.running.destination=="0.0.0.0/0"` {
+		return []Token{
+			{0, IDENTITY, "routes"},
+			{6, DOT, "."},
+			{7, IDENTITY, "running"},
+			{14, DOT, "."},
+			{15, IDENTITY, "destination"},
+			{26, EQFILTER, "=="},
+			{28, STRING, "0.0.0.0/0"},
+			{38, EOF, ""},
+		}, nil
+	}
 	return nil, nil
 }

--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -20,6 +20,8 @@
 package parser
 
 import (
+	"reflect"
+
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
 )
@@ -31,5 +33,51 @@ func New() Parser {
 }
 
 func (p Parser) Parse(tokens []lexer.Token) (ast.Node, error) {
+	tokenRoutes := lexer.Token{Position: 0, Type: lexer.IDENTITY, Literal: "routes"}
+	tokenRunning := lexer.Token{Position: 7, Type: lexer.IDENTITY, Literal: "running"}
+	tokenDestination := lexer.Token{Position: 15, Type: lexer.IDENTITY, Literal: "destination"}
+	tokenDefaultGw := lexer.Token{Position: 28, Type: lexer.STRING, Literal: "0.0.0.0/0"}
+	tokenEqFilter := lexer.Token{Position: 26, Type: lexer.EQFILTER, Literal: "=="}
+
+	if reflect.DeepEqual(tokens, []lexer.Token{
+		tokenRoutes,
+		{Position: 6, Type: lexer.DOT, Literal: "."},
+		tokenRunning,
+		{Position: 14, Type: lexer.DOT, Literal: "."},
+		tokenDestination,
+		tokenEqFilter,
+		tokenDefaultGw,
+		{Position: 38, Type: lexer.EOF, Literal: ""},
+	}) {
+		return ast.Node{
+			Meta: ast.Meta{Position: tokenEqFilter.Position},
+			EqFilter: &ast.TernaryOperator{
+				ast.Node{
+					Meta:     ast.Meta{Position: 0},
+					Terminal: ast.CurrentStateIdentity()},
+				ast.Node{
+					Meta: ast.Meta{Position: 0},
+					Path: &ast.VariadicOperator{
+						ast.Node{
+							Meta:     ast.Meta{Position: tokenRoutes.Position},
+							Terminal: ast.Terminal{Identity: &tokenRoutes.Literal},
+						},
+						ast.Node{
+							Meta:     ast.Meta{Position: tokenRunning.Position},
+							Terminal: ast.Terminal{Identity: &tokenRunning.Literal},
+						},
+						ast.Node{
+							Meta:     ast.Meta{Position: tokenDestination.Position},
+							Terminal: ast.Terminal{Identity: &tokenDestination.Literal},
+						},
+					},
+				},
+				ast.Node{
+					Meta:     ast.Meta{Position: tokenDefaultGw.Position},
+					Terminal: ast.Terminal{String: &tokenDefaultGw.Literal},
+				},
+			},
+		}, nil
+	}
 	return ast.Node{}, nil
 }

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -68,9 +68,10 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 }
 
 func timestampCapturesState(capturesState map[string]types.CaptureState, timeStamp time.Time) {
-	for _, captureState := range capturesState {
+	for captureID, captureState := range capturesState {
 		if captureState.MetaInfo.TimeStamp.IsZero() {
 			captureState.MetaInfo.TimeStamp = timeStamp
+			capturesState[captureID] = captureState
 		}
 	}
 }


### PR DESCRIPTION
Add a test that check that the capture expression
'routes.running.destination="0.0.0.0/0"' capture the expected value and
harcode the lexer/parser/resolver dummies to make it pass.

Also fixed a bug at operations related to meta timestamp.