### PR TITLE
types, cache: Remove Capture level

### DIFF
--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -38,7 +38,7 @@ import (
 // - Meta Info: Extended information about the generated state (e.g. the policy version).
 //
 // On failure, an error is returned.
-func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.CachedState) (types.GeneratedState, error) {
+func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache map[string]types.CaptureState) (types.GeneratedState, error) {
 	var capturesState map[string]types.CaptureState
 	var desiredState []byte
 
@@ -47,7 +47,7 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 
 		capResolver := capture.New(lexer.New(), parser.New(), resolver.New())
 		var err error
-		capturesState, err = capResolver.Resolve(nmpolicy.Capture, cache.Capture, currentState)
+		capturesState, err = capResolver.Resolve(nmpolicy.Capture, cache, currentState)
 		if err != nil {
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
 		}
@@ -58,7 +58,7 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 	timestamp := time.Now().UTC()
 	timestampCapturesState(capturesState, timestamp)
 	return types.GeneratedState{
-		Cache:        types.CachedState{Capture: capturesState},
+		Cache:        capturesState,
 		DesiredState: desiredState,
 		MetaInfo: types.MetaInfo{
 			Version:   "0",

--- a/nmpolicy/types/types.go
+++ b/nmpolicy/types/types.go
@@ -22,12 +22,8 @@ type PolicySpec struct {
 	DesiredState []byte
 }
 
-type CachedState struct {
-	Capture map[string]CaptureState
-}
-
 type GeneratedState struct {
-	Cache        CachedState
+	Cache        map[string]CaptureState
 	DesiredState []byte
 	MetaInfo     MetaInfo
 }
@@ -42,4 +38,4 @@ type MetaInfo struct {
 	TimeStamp time.Time
 }
 
-func NoCache() CachedState { return CachedState{} }
+func NoCache() map[string]CaptureState { return map[string]CaptureState{} }

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -77,8 +77,8 @@ func testPolicyWithCachedCapturesAndNoDesiredStateRef(t *testing.T) {
 		}
 
 		captureTime := time.Now().Add(-5 * time.Minute).UTC()
-		cacheState := types.CachedState{
-			Capture: map[string]types.CaptureState{capID0: {State: []byte("some captured state"), MetaInfo: types.MetaInfo{TimeStamp: captureTime}}},
+		cacheState := map[string]types.CaptureState{
+			capID0: {State: []byte("some captured state"), MetaInfo: types.MetaInfo{TimeStamp: captureTime}},
 		}
 		s, err := nmpolicy.GenerateState(
 			policySpec,
@@ -91,7 +91,7 @@ func testPolicyWithCachedCapturesAndNoDesiredStateRef(t *testing.T) {
 			DesiredState: stateData,
 			MetaInfo:     types.MetaInfo{Version: "0"},
 		}
-		assert.NotEqual(t, s.MetaInfo.TimeStamp, expectedState.Cache.Capture[capID0].MetaInfo.TimeStamp)
+		assert.NotEqual(t, s.MetaInfo.TimeStamp, expectedState.Cache[capID0].MetaInfo.TimeStamp)
 		assert.Equal(t, expectedState, resetTimeStamp(s))
 	})
 }


### PR DESCRIPTION
The type Cache has only one field with is Capture only the capture is
going to be cached. This change remove the Capture level of cache.

Signed-off-by: Quique Llorente <ellorent@redhat.com>