### PR TITLE
main scenario: Implement number and capture entry reference

### DIFF
--- a/nmpolicy/internal/ast/types.go
+++ b/nmpolicy/internal/ast/types.go
@@ -25,6 +25,7 @@ type VariadicOperator []Node
 type Terminal struct {
 	String   *string `json:"string,omitempty"`
 	Identity *string `json:"identity,omitempty"`
+	Number   *int    `json:"number,omitempty"`
 }
 
 type Node struct {

--- a/nmpolicy/internal/parser/errors.go
+++ b/nmpolicy/internal/parser/errors.go
@@ -16,28 +16,58 @@
 
 package parser
 
-import "fmt"
+import (
+	"strings"
+)
 
-type InvalidExpressionError struct {
-	msg string
+type parserError struct {
+	prefix string
+	inner  error
+	msg    string
 }
 
-func (e *InvalidExpressionError) Error() string {
-	return fmt.Sprintf("invalid expression: %s", e.msg)
+func (p parserError) Unwrap() error {
+	return p.inner
 }
 
-type InvalidPathError struct {
-	msg string
+func (p parserError) Error() string {
+	errorMsg := strings.Builder{}
+	errorMsg.WriteString(p.prefix)
+	errorMsg.WriteString(": ")
+	if p.inner != nil {
+		errorMsg.WriteString(p.inner.Error())
+	} else {
+		errorMsg.WriteString(p.msg)
+	}
+	return errorMsg.String()
 }
 
-func (e *InvalidPathError) Error() string {
-	return fmt.Sprintf("invalid path: %s", e.msg)
+const invalidPathErrorPrefix = "invalid path"
+
+func wrapWithInvalidPathError(err error) *parserError {
+	return &parserError{
+		prefix: invalidPathErrorPrefix,
+		inner:  err,
+	}
 }
 
-type InvalidEqualityFilter struct {
-	msg string
+func invalidPathError(msg string) *parserError {
+	return &parserError{
+		prefix: invalidPathErrorPrefix,
+		msg:    msg,
+	}
 }
 
-func (e *InvalidEqualityFilter) Error() string {
-	return fmt.Sprintf("invalid equality filter: %s", e.msg)
+func invalidEqualityFilterError(msg string) *parserError {
+	return &parserError{
+		prefix: "invalid equality filter",
+		msg:    msg,
+	}
+}
+
+func invalidExpressionError(msg string) *parserError {
+	return &parserError{
+		prefix: "invalid expression",
+		msg:    msg,
+	}
 }

--- a/nmpolicy/internal/resolver/terminal.go
+++ b/nmpolicy/internal/resolver/terminal.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func newTerminalFromInterface(iface interface{}) (*ast.Terminal, error) {
+	switch v := iface.(type) {
+	case string:
+		return &ast.Terminal{String: &v}, nil
+	default:
+		return nil, fmt.Errorf("unexpected terminal type %T", v)
+	}
+}


### PR DESCRIPTION
To continue with the next capture entry `routes.running.next-hop-interface==capture.default-gw.routes.running.0.next-hop-interface` the following features need to be implemented:
- parsing and resolving numeric values to reference a list index.
- understand capture reference on paths like `capture.default-gw` and resolve it if it's not already resolved
- walk the path after a capture entry reference so it returns not state but the value it points to.