### PR TITLE
expander: Inserting the captured snippet to the desired state

### DIFF
--- a/nmpolicy/internal/capture/capture_entry.go
+++ b/nmpolicy/internal/capture/capture_entry.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture
+
+import "github.com/nmstate/nmpolicy/nmpolicy/types"
+
+type CaptureEntry struct {
+	CaptureCache map[string]types.CaptureState
+}
+
+func (c CaptureEntry) ResolveCaptureEntryPath(
+	capturePath string) (interface{}, error) {
+	return nil, nil
+}

--- a/nmpolicy/internal/expander/state_expander.go
+++ b/nmpolicy/internal/expander/state_expander.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expander
+
+import (
+	"fmt"
+	"regexp"
+
+	yaml "sigs.k8s.io/yaml"
+)
+
+type StateExpander struct {
+	capResolver CapturePathResolver
+}
+
+type CapturePathResolver interface {
+	ResolveCaptureEntryPath(capturePath string) (interface{}, error)
+}
+
+func New(capResolver CapturePathResolver) StateExpander {
+	return StateExpander{capResolver: capResolver}
+}
+
+func (c StateExpander) Expand(marshaledDesiredState []byte) ([]byte, error) {
+	desiredState, err := unmarshalState(marshaledDesiredState)
+	if err != nil {
+		return nil, fmt.Errorf("expand error: %v", err)
+	}
+
+	expandedState, err := c.expandState(desiredState)
+	if err != nil {
+		return nil, fmt.Errorf("expand error: %v", err)
+	}
+
+	marshaledExpandedState, err := yaml.Marshal(expandedState)
+	if err != nil {
+		return nil, fmt.Errorf("expand error: failed marshaling the expanded state : %v", err)
+	}
+	return marshaledExpandedState, nil
+}
+
+func unmarshalState(desrideState []byte) (interface{}, error) {
+	var unmarshaledState interface{}
+	err := yaml.Unmarshal(desrideState, &unmarshaledState)
+	if err != nil {
+		return nil, fmt.Errorf("failed unmarshaling the state %v : %v", desrideState, err)
+	}
+
+	return unmarshaledState, nil
+}
+
+func (c StateExpander) expandState(state interface{}) (interface{}, error) {
+	switch stateValue := state.(type) {
+	case nil:
+		return state, nil
+	case string:
+		return c.expandString(stateValue)
+
+	case map[string]interface{}:
+		return c.expandMap(stateValue)
+	case []interface{}:
+		return c.exapndSlice(stateValue)
+	default:
+		return state, nil
+	}
+}
+
+func (c StateExpander) exapndSlice(sliceState []interface{}) ([]interface{}, error) {
+	for i, value := range sliceState {
+		expandedValue, err := c.expandState(value)
+		if err != nil {
+			return nil, err
+		}
+		sliceState[i] = expandedValue
+	}
+	return sliceState, nil
+}
+
+func (c StateExpander) expandMap(mapState map[string]interface{}) (map[string]interface{}, error) {
+	for key, value := range mapState {
+		expandedValue, err := c.expandState(value)
+		mapState[key] = expandedValue
+		if err != nil {
+			return nil, err
+		}
+	}
+	return mapState, nil
+}
+
+func (c StateExpander) expandString(stringState string) (interface{}, error) {
+	re := regexp.MustCompile(`^{{ (.*) }}$`)
+	submatch := re.FindStringSubmatch(stringState)
+
+	if len(submatch) == 0 {
+		return stringState, nil
+	}
+
+	const captureSubmatchLength = 2
+	if len(submatch) != captureSubmatchLength {
+		return nil, fmt.Errorf("the capture expression has wrong format %s", stringState)
+	}
+
+	capturePath := submatch[1]
+	resolvedPath, err := c.capResolver.ResolveCaptureEntryPath(capturePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resolvedPath, nil
+}

--- a/nmpolicy/internal/expander/state_expander_test.go
+++ b/nmpolicy/internal/expander/state_expander_test.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expander
+
+import (
+	"fmt"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	yaml "sigs.k8s.io/yaml"
+)
+
+func TestExpanderCapturesAreMapValues(t *testing.T) {
+	desiredState := `
+interfaces:
+- name: br1
+  description: Linux bridge with base interface as a port
+  type: linux-bridge
+  state: up
+  ipv4: "{{ capture.base-iface.interfaces[0].ipv4 }}"
+  bridge:
+    options:
+      stp:
+        enabled: false
+    port:
+    - name: "{{ capture.base-iface.interfaces[0].name }}"
+routes:
+  config: "{{ capture.bridge-routes-takeover.running }}"
+`
+	expectedExandedState := `interfaces:
+- bridge:
+    options:
+      stp:
+        enabled: false
+    port:
+    - name: eth1
+  description: Linux bridge with base interface as a port
+  ipv4: 1.2.3.4
+  name: br1
+  state: up
+  type: linux-bridge
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+  - destination: 1.1.1.0/24
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254`
+
+	routes := `
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+  - destination: 1.1.1.0/24
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+`
+	unmarshaledRoutes, err := unmarshalState([]byte(routes))
+	assert.NoError(t, err)
+	capturerStub := pathCapturerStub{failResolve: false,
+		pathResults: map[string]interface{}{"capture.base-iface.interfaces[0].ipv4": "1.2.3.4", "capture.base-iface.interfaces[0].name": "eth1",
+			"capture.bridge-routes-takeover.running": unmarshaledRoutes},
+	}
+	expandedState, err := New(capturerStub).Expand([]byte(desiredState))
+	assert.NoError(t, err)
+	verifyResult(t, expectedExandedState, expandedState)
+}
+
+func TestExpanderCaptureIsTopLevel(t *testing.T) {
+	desiredState := `
+"{{ capture.base-iface }}"
+`
+	expectedExandedState := `interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 10.244.0.1
+        prefix-length: 24
+      - ip: 169.254.1.0
+        prefix-length: 16
+      dhcp: false
+      enabled: true`
+
+	unmarshaledInterfaces, err := unmarshalState([]byte(expectedExandedState))
+	assert.NoError(t, err)
+
+	capturerStub := pathCapturerStub{failResolve: false,
+		pathResults: map[string]interface{}{"capture.base-iface": unmarshaledInterfaces},
+	}
+	expandedState, err := New(capturerStub).Expand([]byte(desiredState))
+	assert.NoError(t, err)
+	verifyResult(t, expectedExandedState, expandedState)
+}
+
+func TestExpanderResolveCaptureFails(t *testing.T) {
+	desiredState := `
+"{{ capture.enabled-iface }}"
+`
+	capturerStub := pathCapturerStub{failResolve: true}
+	expandedState, err := New(capturerStub).Expand([]byte(desiredState))
+
+	assert.Error(t, err)
+	assert.Nil(t, expandedState)
+}
+
+func verifyResult(t *testing.T, expectedExandedState string, expandedState []byte) {
+	expectedState := make(map[string]interface{})
+	actualState := make(map[string]interface{})
+	assert.NoError(t, yaml.Unmarshal([]byte(expectedExandedState), &expectedState))
+	assert.NoError(t, yaml.Unmarshal(expandedState, &actualState))
+	assert.Equal(t, expectedState, actualState)
+}
+
+type pathCapturerStub struct {
+	failResolve bool
+	pathResults map[string]interface{}
+}
+
+func (c pathCapturerStub) ResolveCaptureEntryPath(capturePath string) (interface{}, error) {
+	if c.failResolve {
+		return nil, fmt.Errorf("resolved failed")
+	}
+
+	result, found := c.pathResults[capturePath]
+	if !found {
+		return nil, fmt.Errorf("couldn't find capture path")
+	}
+
+	return result, nil
+}

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expander"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
@@ -53,7 +54,11 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
 		}
 
-		// TODO: Resolve/expend the desired state.
+		stateExpander := expander.New(capture.CaptureEntry{CaptureCache: capturesState})
+		desiredState, err = stateExpander.Expand(desiredState)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
 	}
 
 	timestamp := time.Now().UTC()

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -54,7 +54,8 @@ func testPolicyWithOnlyDesiredState(t *testing.T) {
 	// When a basic input with only the desired state is provided,
 	// the policy just passes it as is to the output with no modifications.
 	t.Run("with only desired state", func(t *testing.T) {
-		stateData := []byte(`this is not a legal yaml format!`)
+		stateData := []byte(`this is not a legal yaml format!
+`)
 		policySpec := types.PolicySpec{
 			DesiredState: stateData,
 		}
@@ -72,7 +73,8 @@ func testPolicyWithOnlyDesiredState(t *testing.T) {
 
 func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 	t.Run("with all captures cached and desired state that has no ref", func(t *testing.T) {
-		stateData := []byte(`this is not a legal yaml format!`)
+		stateData := []byte(`this is not a legal yaml format!
+`)
 		const capID0 = "cap0"
 		policySpec := types.PolicySpec{
 			Capture: map[string]string{
@@ -101,8 +103,7 @@ func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 
 func testPolicyWithFilterCaptureAndDesiredStateWithoutRef(t *testing.T) {
 	t.Run("with a eqfilter capture expression and desired state that has no ref", func(t *testing.T) {
-		stateData := []byte(`
-routes:
+		stateData := []byte(`routes:
   running:
   - destination: 0.0.0.0/0
     next-hop-address: 192.168.100.1
@@ -112,36 +113,6 @@ routes:
     next-hop-address: 192.168.100.1
     next-hop-interface: eth1
     table-id: 254
-  config:
-  - destination: 0.0.0.0/0
-    next-hop-address: 192.168.100.1
-    next-hop-interface: eth1
-    table-id: 254
-  - destination: 1.1.1.0/24
-    next-hop-address: 192.168.100.1
-    next-hop-interface: eth1
-    table-id: 254
-interfaces:
-  - name: eth1
-    type: ethernet
-    state: up
-    ipv4:
-      address:
-      - ip: 10.244.0.1
-        prefix-length: 24
-      - ip: 169.254.1.0
-        prefix-length: 16
-      dhcp: false
-      enabled: true
-  - name: eth2
-    type: ethernet
-    state: down
-    ipv4:
-      address:
-      - ip: 1.2.3.4
-        prefix-length: 24
-      dhcp: false
-      enabled: false
 `)
 		const capID0 = "cap0"
 		policySpec := types.PolicySpec{
@@ -164,8 +135,7 @@ interfaces:
 			Cache: types.CachedState{
 				Capture: map[string]types.CaptureState{
 					capID0: {
-						State: []byte(`
-routes:
+						State: []byte(`routes:
   running:
   - destination: 0.0.0.0/0
     next-hop-address: 192.168.100.1
@@ -191,8 +161,7 @@ routes:
 
 func testGenerateUniqueTimestamps(t *testing.T) {
 	t.Run("with eq filter and no desired state should set unique timestamps", func(t *testing.T) {
-		stateData := []byte(`
-routes:
+		stateData := []byte(`routes:
   running:
   - destination: 0.0.0.0/0
     next-hop-address: 192.168.100.1


### PR DESCRIPTION
This PR is implementing the state expander. The expander is responsible to substitute the capture references (e.g `{{ capture.primary-nic.interfaces.0.ipv4.dhcp }}`) in the desired state with the resolved captured value.