### PR TITLE
resolver, filter: Move out error prefix

### DIFF
--- a/nmpolicy/internal/resolver/errors.go
+++ b/nmpolicy/internal/resolver/errors.go
@@ -18,14 +18,14 @@ package resolver
 
 import "fmt"
 
-func filterError(format string, a ...interface{}) error {
-	return fmt.Errorf("invalid filter: %v", fmt.Errorf(format, a...))
-}
-
 func pathError(format string, a ...interface{}) error {
 	return fmt.Errorf("invalid path: %v", fmt.Errorf(format, a...))
 }
 
 func wrapWithResolveError(err error) error {
 	return fmt.Errorf("resolve error: %v", err)
+}
+
+func wrapWithEqFilterError(err error) error {
+	return fmt.Errorf("eqfilter error: %v", err)
 }

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -26,7 +26,7 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 	filtered, err := applyFuncOnPath(inputState, path, expectedNode, mapContainsValue, true)
 
 	if err != nil {
-		return nil, filterError("error applying operation on the path : %v", err)
+		return nil, fmt.Errorf("failed applying operation on the path: %v", err)
 	}
 
 	if filtered == nil {
@@ -35,7 +35,7 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 
 	filteredMap, ok := filtered.(map[string]interface{})
 	if !ok {
-		return nil, filterError("error converting filtering result to a map")
+		return nil, fmt.Errorf("failed converting filtering result to a map")
 	}
 	return filteredMap, nil
 }
@@ -56,11 +56,11 @@ func isEqual(obtainedValue interface{}, desiredValue ast.Node) (bool, error) {
 func mapContainsValue(mapToFilter map[string]interface{}, filterKey string, expectedNode ast.Node) (interface{}, error) {
 	obtainedValue, ok := mapToFilter[filterKey]
 	if !ok {
-		return nil, filterError("cannot find key %s in %v", filterKey, obtainedValue)
+		return nil, fmt.Errorf("cannot find key %s in %v", filterKey, mapToFilter)
 	}
 	valueIsEqual, err := isEqual(obtainedValue, expectedNode)
 	if err != nil {
-		return nil, filterError("error comparing the expected and obtained values : %v", err)
+		return nil, fmt.Errorf("error comparing the expected and obtained values : %v", err)
 	}
 	if valueIsEqual {
 		return mapToFilter, nil

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -68,7 +68,11 @@ func (r Resolver) resolveAST(captureAST ast.Node, currentState map[string]interf
 			return nil, err
 		}
 
-		return filter(inputSource, *path, *filteredValue)
+		filteredState, err := filter(inputSource, *path, *filteredValue)
+		if err != nil {
+			return nil, wrapWithEqFilterError(err)
+		}
+		return filteredState, nil
 	}
 	return nil, fmt.Errorf("root node has unsupported operation : %v", captureAST)
 }

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -88,7 +88,7 @@ func runTest(t *testing.T, testToRun test) {
 			assert.Equal(t, expectedState, actualState)
 		}
 	} else {
-		assert.Error(t, err)
+		assert.EqualError(t, err, testToRun.err)
 	}
 }
 
@@ -235,7 +235,10 @@ eqfilter:
 - pos: 7
   string: 10.244.0.1
 `},
-			err: "invalid type on path",
+			err: "resolve error: eqfilter error: failed applying operation on the path: " +
+				"error comparing the expected and obtained values : " +
+				"the value [map[ip:10.244.0.1 prefix-length:24] map[ip:169.254.1.0 prefix-length:16]] of type []interface {} " +
+				"not supported,curretly only string values are supported",
 		}
 		runTest(t, testToRun)
 	})
@@ -259,7 +262,9 @@ eqfilter:
 - pos: 6
   string: eth0
 `},
-			err: "invalid path",
+			err: "resolve error: eqfilter error: failed applying operation on the path: cannot find key name-invalid-path in " +
+				"map[ipv4:map[address:[map[ip:10.244.0.1 prefix-length:24] " +
+				"map[ip:169.254.1.0 prefix-length:16]] dhcp:false enabled:true] name:eth1 state:up type:ethernet]",
 		}
 		runTest(t, testToRun)
 	})


### PR DESCRIPTION
Using a error prefix at a recursive function make the final error find
the prefix repeated. This change remove that by adding the prefix at the
recursive function caller, it also compare the error string at tests.