### PR TITLE
parser: Allow reuse of the parser

### DIFF
--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -35,7 +35,7 @@ func New() *Parser {
 }
 
 func (p *Parser) Parse(tokens []lexer.Token) (ast.Node, error) {
-	p.tokens = tokens
+	p.reset(tokens)
 	node, err := p.parse()
 	if err != nil {
 		return ast.Node{}, err
@@ -163,4 +163,9 @@ func (p *Parser) parseEqFilter() (*ast.Node, error) {
 		return nil, &InvalidEqualityFilter{"right hand argument is not a string"}
 	}
 	return operator, nil
+}
+
+func (p *Parser) reset(tokens []lexer.Token) {
+	*p = *New()
+	p.tokens = tokens
 }


### PR DESCRIPTION
Since the tokens are not passed at the constructor the parser the tokens
member is reset at `Resolve` functions, but the tokens index has to be
reset too. This change reset the Parser at full at `Resolve` function.