### PR TITLE
capture: Wire up ResolveCaptureEntryPath

### DIFF
--- a/nmpolicy/internal/capture/capture.go
+++ b/nmpolicy/internal/capture/capture.go
@@ -42,6 +42,7 @@ type Parser interface {
 
 type Resolver interface {
 	Resolve(astPool map[string]ast.Node, state []byte, capturedStates map[string]map[string]interface{}) (map[string]types.CaptureState, error)
+	ResolveCaptureEntryPath(captureEntryPathAST ast.Node, capturedStates map[string]map[string]interface{}) (interface{}, error)
 }
 
 func New(leXer Lexer, parser Parser, resolver Resolver) Capture {

--- a/nmpolicy/internal/capture/capture_entry_test.go
+++ b/nmpolicy/internal/capture/capture_entry_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
+	"github.com/nmstate/nmpolicy/nmpolicy/types"
+)
+
+func TestCaptureEntry(t *testing.T) {
+	t.Run("test CaptureEntry", func(t *testing.T) {
+		testResolveCaptureEntryPathSuccess(t)
+
+		testResolveCaptureEntryPathWithLexFailure(t)
+		testResolveCaptureEntryPathWithParseFailure(t)
+		testResolveCaptureEntryPathWithResolveFailure(t)
+	})
+}
+
+func testResolveCaptureEntryPathSuccess(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath success", func(t *testing.T) {
+		capturedStates := map[string]types.CaptureState{}
+		captureEntryResolver, err := captureEntryResolverWithDefaultStubs(capturedStates)
+		assert.NoError(t, err)
+		obtainedValue, err := captureEntryResolver.ResolveCaptureEntryPath("my expression")
+		assert.NoError(t, err)
+		assert.Equal(t, defaultStubValue("my expression"), obtainedValue)
+	})
+}
+
+func testResolveCaptureEntryPathWithLexFailure(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath lex failure", func(t *testing.T) {
+		capturedStates := map[string]types.CaptureState{}
+		captureEntryResolver, err := capture.NewCaptureEntryWithLexerParserResolver(capturedStates,
+			lexerStub{failLex: true}, parserStub{}, resolverStub{})
+		assert.NoError(t, err)
+		_, err = captureEntryResolver.ResolveCaptureEntryPath("my expression")
+		assert.Error(t, err)
+	})
+}
+
+func testResolveCaptureEntryPathWithParseFailure(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath parser failure", func(t *testing.T) {
+		capturedStates := map[string]types.CaptureState{}
+		captureEntryResolver, err := capture.NewCaptureEntryWithLexerParserResolver(capturedStates,
+			lexerStub{}, parserStub{failParse: true}, resolverStub{})
+		assert.NoError(t, err)
+		_, err = captureEntryResolver.ResolveCaptureEntryPath("my expression")
+		assert.Error(t, err)
+	})
+}
+
+func testResolveCaptureEntryPathWithResolveFailure(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath resolver failure", func(t *testing.T) {
+		capturedStates := map[string]types.CaptureState{}
+		captureEntryResolver, err := capture.NewCaptureEntryWithLexerParserResolver(capturedStates,
+			lexerStub{}, parserStub{}, resolverStub{failResolve: true})
+		assert.NoError(t, err)
+		_, err = captureEntryResolver.ResolveCaptureEntryPath("my expression")
+		assert.Error(t, err)
+	})
+}
+
+func captureEntryResolverWithDefaultStubs(capturedStates map[string]types.CaptureState) (capture.CaptureEntry, error) {
+	return capture.NewCaptureEntryWithLexerParserResolver(capturedStates, lexerStub{}, parserStub{}, resolverStub{})
+}

--- a/nmpolicy/internal/capture/capture_test.go
+++ b/nmpolicy/internal/capture/capture_test.go
@@ -17,18 +17,12 @@
 package capture_test
 
 import (
-	"fmt"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/yaml"
-
-	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
-	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
 	"github.com/nmstate/nmpolicy/nmpolicy/types"
-	"github.com/nmstate/nmpolicy/nmpolicy/types/typestest"
 )
 
 func TestBasicPolicy(t *testing.T) {
@@ -196,69 +190,4 @@ func testResolveFailure(t *testing.T) {
 		)
 		assert.Error(t, err)
 	})
-}
-
-type lexerStub struct {
-	failLex bool
-}
-
-func (l lexerStub) Lex(_ string) ([]lexer.Token, error) {
-	if l.failLex {
-		return nil, fmt.Errorf("lex failed")
-	}
-	return nil, nil
-}
-
-type parserStub struct {
-	failParse bool
-}
-
-func (p parserStub) Parse(_ []lexer.Token) (ast.Node, error) {
-	if p.failParse {
-		return ast.Node{}, fmt.Errorf("parse failed")
-	}
-	return ast.Node{}, nil
-}
-
-type resolverStub struct {
-	failResolve bool
-}
-
-func (r resolverStub) Resolve(astPool map[string]ast.Node,
-	state []byte, capturedStates map[string]map[string]interface{}) (map[string]types.CaptureState, error) {
-	if r.failResolve {
-		return nil, fmt.Errorf("resolve failed")
-	}
-	capsState := map[string]types.CaptureState{}
-	for id := range astPool {
-		capsState[id] = types.CaptureState{}
-	}
-	marshaledCapturedStates, err := marshalCapturedStates(capturedStates)
-	if err != nil {
-		return nil, err
-	}
-	for id, capturedState := range marshaledCapturedStates {
-		capsState[id] = capturedState
-	}
-	return capsState, nil
-}
-
-func marshalCapturedStates(capturedStates map[string]map[string]interface{}) (map[string]types.CaptureState, error) {
-	marshaledCapturedStates := map[string]types.CaptureState{}
-	for id, capturedState := range capturedStates {
-		marshaledCapturedState := types.CaptureState{}
-		var err error
-		marshaledCapturedState.State, err = yaml.Marshal(capturedState)
-		if err != nil {
-			return nil, err
-		}
-		marshaledCapturedStates[id] = marshaledCapturedState
-	}
-	return marshaledCapturedStates, nil
-}
-
-func formatYAML(t *testing.T, unformatedYAML string) []byte {
-	formatted, err := typestest.FormatYAML([]byte(unformatedYAML))
-	assert.NoError(t, err)
-	return formatted
 }

--- a/nmpolicy/internal/capture/capture_test.go
+++ b/nmpolicy/internal/capture/capture_test.go
@@ -42,8 +42,7 @@ func TestBasicPolicy(t *testing.T) {
 
 func testNoExpressions(t *testing.T) {
 	t.Run("resolve with no expression", func(t *testing.T) {
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		resolvedCaps, err := capCtrl.Resolve(
+		resolvedCaps, err := captureResolverWithDefaultStubs().Resolve(
 			map[string]string{},
 			map[string]types.CaptureState{"cap0": {State: []byte("some captured state")}},
 			[]byte("some state"),
@@ -56,8 +55,7 @@ func testNoExpressions(t *testing.T) {
 
 func testNoCacheAndState(t *testing.T) {
 	t.Run("resolve with no cache and state", func(t *testing.T) {
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		resolvedCaps, err := capCtrl.Resolve(
+		resolvedCaps, err := captureResolverWithDefaultStubs().Resolve(
 			map[string]string{"cap0": "my expression"},
 			map[string]types.CaptureState{},
 			[]byte{},
@@ -75,8 +73,7 @@ func testAllCapturesCached(t *testing.T) {
 			"cap1": {State: formatYAML(t, "name: another captured state")},
 		}
 
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		resolvedCaps, err := capCtrl.Resolve(
+		resolvedCaps, err := captureResolverWithDefaultStubs().Resolve(
 			map[string]string{
 				"cap0": "my expression",
 				"cap1": "another expression",
@@ -93,15 +90,14 @@ func testResolvingExpressions(t *testing.T) {
 	t.Run("resolve expressions", func(t *testing.T) {
 		const capID = "cap0"
 
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		resolvedCaps, err := capCtrl.Resolve(
+		resolvedCaps, err := captureResolverWithDefaultStubs().Resolve(
 			map[string]string{capID: "my expression"},
 			map[string]types.CaptureState{},
 			[]byte("some state"),
 		)
 		assert.NoError(t, err)
 
-		assert.Equal(t, map[string]types.CaptureState{capID: {}}, resolvedCaps)
+		assert.Equal(t, map[string]types.CaptureState{capID: defaultStubCapturedState("my expression")}, resolvedCaps)
 	})
 }
 
@@ -111,9 +107,8 @@ func testExpressionsWithPartialCache(t *testing.T) {
 		const capID1 = "cap1"
 
 		capCache := map[string]types.CaptureState{capID0: {State: formatYAML(t, "name: some captured state")}}
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
 
-		resolvedCaps, err := capCtrl.Resolve(
+		resolvedCaps, err := captureResolverWithDefaultStubs().Resolve(
 			map[string]string{
 				capID0: "my expression",
 				capID1: "another expression",
@@ -124,7 +119,7 @@ func testExpressionsWithPartialCache(t *testing.T) {
 		assert.NoError(t, err)
 
 		expectedCaps := capCache
-		expectedCaps[capID1] = types.CaptureState{}
+		expectedCaps[capID1] = defaultStubCapturedState("another expression")
 		assert.Equal(t, expectedCaps, resolvedCaps)
 	})
 }
@@ -138,9 +133,8 @@ func testExpressionsWithOverCache(t *testing.T) {
 			capID0: {State: formatYAML(t, "name: some captured state")},
 			capID1: {State: formatYAML(t, "name: another captured state")},
 		}
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
 
-		resolvedCaps, err := capCtrl.Resolve(
+		resolvedCaps, err := captureResolverWithDefaultStubs().Resolve(
 			map[string]string{
 				capID0: "my expression",
 			},
@@ -190,4 +184,8 @@ func testResolveFailure(t *testing.T) {
 		)
 		assert.Error(t, err)
 	})
+}
+
+func captureResolverWithDefaultStubs() capture.Capture {
+	return capture.New(lexerStub{}, parserStub{}, resolverStub{})
 }

--- a/nmpolicy/internal/capture/stubs_test.go
+++ b/nmpolicy/internal/capture/stubs_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
+	"github.com/nmstate/nmpolicy/nmpolicy/types"
+	"github.com/nmstate/nmpolicy/nmpolicy/types/typestest"
+)
+
+type lexerStub struct {
+	failLex bool
+}
+
+func (l lexerStub) Lex(_ string) ([]lexer.Token, error) {
+	if l.failLex {
+		return nil, fmt.Errorf("lex failed")
+	}
+	return nil, nil
+}
+
+type parserStub struct {
+	failParse bool
+}
+
+func (p parserStub) Parse(_ []lexer.Token) (ast.Node, error) {
+	if p.failParse {
+		return ast.Node{}, fmt.Errorf("parse failed")
+	}
+	return ast.Node{}, nil
+}
+
+type resolverStub struct {
+	failResolve bool
+}
+
+func (r resolverStub) Resolve(astPool map[string]ast.Node,
+	state []byte, capturedStates map[string]map[string]interface{}) (map[string]types.CaptureState, error) {
+	if r.failResolve {
+		return nil, fmt.Errorf("resolve failed")
+	}
+	capsState := map[string]types.CaptureState{}
+	for id := range astPool {
+		capsState[id] = types.CaptureState{}
+	}
+	marshaledCapturedStates, err := marshalCapturedStates(capturedStates)
+	if err != nil {
+		return nil, err
+	}
+	for id, capturedState := range marshaledCapturedStates {
+		capsState[id] = capturedState
+	}
+	return capsState, nil
+}
+
+func marshalCapturedStates(capturedStates map[string]map[string]interface{}) (map[string]types.CaptureState, error) {
+	marshaledCapturedStates := map[string]types.CaptureState{}
+	for id, capturedState := range capturedStates {
+		marshaledCapturedState := types.CaptureState{}
+		var err error
+		marshaledCapturedState.State, err = yaml.Marshal(capturedState)
+		if err != nil {
+			return nil, err
+		}
+		marshaledCapturedStates[id] = marshaledCapturedState
+	}
+	return marshaledCapturedStates, nil
+}
+
+func formatYAML(t *testing.T, unformatedYAML string) []byte {
+	formatted, err := typestest.FormatYAML([]byte(unformatedYAML))
+	assert.NoError(t, err)
+	return formatted
+}

--- a/nmpolicy/internal/capture/stubs_test.go
+++ b/nmpolicy/internal/capture/stubs_test.go
@@ -77,7 +77,7 @@ func (r resolverStub) Resolve(astPool map[string]ast.Node,
 }
 
 func (r resolverStub) ResolveCaptureEntryPath(captureEntryPathAST ast.Node,
-	capturedStates map[string]types.CaptureState) (interface{}, error) {
+	capturedStates map[string]map[string]interface{}) (interface{}, error) {
 	if r.failResolve {
 		return nil, fmt.Errorf("resolve capture entry path failed")
 	}
@@ -86,8 +86,12 @@ func (r resolverStub) ResolveCaptureEntryPath(captureEntryPathAST ast.Node,
 
 func defaultStubCapturedState(expression string) types.CaptureState {
 	return types.CaptureState{
-		State: []byte(fmt.Sprintf("resolver: parser: lexer: %s", expression)),
+		State: []byte(defaultStubValue(expression)),
 	}
+}
+
+func defaultStubValue(expression string) string {
+	return fmt.Sprintf("resolver: parser: lexer: %s", expression)
 }
 
 func marshalCapturedStates(capturedStates map[string]map[string]interface{}) (map[string]types.CaptureState, error) {

--- a/nmpolicy/internal/lexer/lexer.go
+++ b/nmpolicy/internal/lexer/lexer.go
@@ -24,19 +24,30 @@ import (
 )
 
 // Lexer struct is used to tokenize values returned by a reader.
+type Lexer struct{}
+
 type lexer struct {
 	scn *scanner.Scanner
 }
 
 // NewLexer construct a Lexer using reader as the input.
-func New() *lexer {
-	return &lexer{}
+func New() Lexer {
+	return Lexer{}
+}
+
+func newLexer(expression string) *lexer {
+	return &lexer{scn: scanner.New(strings.NewReader(expression))}
 }
 
 // Lex scans the input for the next token.
 // It returns a Token struct with position, type, and the literal value.
-func (l *lexer) Lex(expression string) ([]Token, error) {
-	l.scn = scanner.New(strings.NewReader(expression))
+func (Lexer) Lex(expression string) ([]Token, error) {
+	return newLexer(expression).Lex()
+}
+
+// Lex scans the input for the next token.
+// It returns a Token struct with position, type, and the literal value.
+func (l *lexer) Lex() ([]Token, error) {
 	// keep looping until we return a token
 	tokens := []Token{}
 	for {

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -253,7 +253,7 @@ func runTest(t *testing.T, tests []test) {
 	}
 }
 
-func runTestWithParser(t *testing.T, testToRun test, p *parser.Parser) {
+func runTestWithParser(t *testing.T, testToRun test, p parser.Parser) {
 	obtainedAST, obtainedErr := p.Parse(testToRun.tokens)
 	if testToRun.expected.err != "" {
 		assert.EqualError(t, obtainedErr, testToRun.expected.err)

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package resolver
+package resolver_test
 
 import (
 	"testing"
@@ -23,6 +23,7 @@ import (
 	yaml "sigs.k8s.io/yaml"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
 )
 
 var sourceYAML string = `
@@ -85,10 +86,7 @@ func runTest(t *testing.T, testToRun test) {
 
 	capturedStates, err := unmarshalCapturedState(testToRun.capturedStates)
 	assert.NoError(t, err)
-	resolver := New()
-	resolver.capturedStates = capturedStates
-
-	resultStates, err := resolver.Resolve(astPool, []byte(sourceYAML))
+	resultStates, err := resolver.New().Resolve(astPool, []byte(sourceYAML), capturedStates)
 	if testToRun.err == "" {
 		assert.NoError(t, err)
 		expectedState := make(map[string]interface{})

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -54,7 +54,12 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
 		}
 
-		stateExpander := expander.New(capture.CaptureEntry{CaptureCache: capturesState})
+		captureEntryPathResolver, err := capture.NewCaptureEntry(capturesState)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
+
+		stateExpander := expander.New(captureEntryPathResolver)
 		desiredState, err = stateExpander.Expand(desiredState)
 		if err != nil {
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)

--- a/nmpolicy/types/typestest/typestest.go
+++ b/nmpolicy/types/typestest/typestest.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package typestest
+
+import (
+	"sigs.k8s.io/yaml"
+)
+
+func FormatYAML(unformatedYAML []byte) ([]byte, error) {
+	unmarshaled := map[string]interface{}{}
+
+	err := yaml.Unmarshal(unformatedYAML, &unmarshaled)
+	if err != nil {
+		return nil, err
+	}
+
+	marshaled, err := yaml.Marshal(unmarshaled)
+	if err != nil {
+		return nil, err
+	}
+	return marshaled, nil
+}


### PR DESCRIPTION
The ResolveCaptureEntryPath implementation is empty, this PR do the
wiring to connect `CaptureEntry` to lexer, parser and resolver. It also
extend the test stubs so the output is syntetized from the inputs.

After merging this we have to create some issues with the following tech debt:
- The `capturedStates` YAMLs are unmarshaled multiple times since we are passing marshaled version to the resolver
- The `CaptureEntry` has to be renamed to `EntryPathResolver` so we can do `captureEntryPathResolver := capture.EntryPathResolver` and then we use it like `captureEntryPath.Resolve(...)`
- The `Capture` has to be renamed as `Resolver` so we can do `captureResolver := capture.Resolver` and then `captureResolver.Resolve(...)`.