### PR TITLE
[tech debt] Rename structs and variables to follow name conventions related to the capture field.

### DIFF
--- a/nmpolicy/internal/capture/capture.go
+++ b/nmpolicy/internal/capture/capture.go
@@ -41,6 +41,7 @@ type Parser interface {
 
 type Resolver interface {
 	Resolve(astPool map[string]ast.Node, state []byte) (resolver.Result, error)
+	ResolveCaptureEntryPath(captureEntryPathAST ast.Node, capturdStates map[string]map[string]interface{}) (interface{}, error)
 }
 
 func New(l Lexer, p Parser, r Resolver) Capture {
@@ -85,9 +86,7 @@ func (c Capture) Resolve(
 	for capID, capState := range capturesState {
 		resolverResult.Marshaled[capID] = capState
 	}
-	return Result{
-		resolverResult: resolverResult,
-	}, nil
+	return NewResult(c.lexer, c.parser, c.resolver, resolverResult), nil
 }
 
 func filterOutExprBasedOnCachedCaptures(capturesExpr map[string]string, capturesCache map[string]types.CaptureState) map[string]string {

--- a/nmpolicy/internal/capture/capture.go
+++ b/nmpolicy/internal/capture/capture.go
@@ -54,7 +54,7 @@ func New(l Lexer, p Parser, r Resolver) Capture {
 
 func (c Capture) Resolve(
 	capturesExpr map[string]string,
-	capturesCache map[string]types.CaptureState,
+	capturesCache map[string]types.CapturedState,
 	state []byte) (Result, error) {
 	if len(capturesExpr) == 0 || len(state) == 0 && len(capturesCache) == 0 {
 		return Result{}, nil
@@ -89,21 +89,21 @@ func (c Capture) Resolve(
 	return NewResult(c.lexer, c.parser, c.resolver, resolverResult), nil
 }
 
-func filterOutExprBasedOnCachedCaptures(capturesExpr map[string]string, capturesCache map[string]types.CaptureState) map[string]string {
+func filterOutExprBasedOnCachedCaptures(capturesExpr map[string]string, capturesCache map[string]types.CapturedState) map[string]string {
 	for capID := range capturesCache {
 		delete(capturesExpr, capID)
 	}
 	return capturesExpr
 }
 
-func filterCacheBasedOnExprCaptures(capsState map[string]types.CaptureState, capsExpr map[string]string) map[string]types.CaptureState {
-	caps := map[string]types.CaptureState{}
+func filterCacheBasedOnExprCaptures(capsState map[string]types.CapturedState, capsExpr map[string]string) map[string]types.CapturedState {
+	caps := map[string]types.CapturedState{}
 
 	for capID := range capsExpr {
 		if capState, ok := capsState[capID]; ok {
 			state := append([]byte{}, capState.State...)
 
-			caps[capID] = types.CaptureState{
+			caps[capID] = types.CapturedState{
 				State:    state,
 				MetaInfo: capState.MetaInfo,
 			}

--- a/nmpolicy/internal/capture/capture_test.go
+++ b/nmpolicy/internal/capture/capture_test.go
@@ -45,7 +45,7 @@ func testNoExpressions(t *testing.T) {
 		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
 		result, err := capCtrl.Resolve(
 			map[string]string{},
-			map[string]types.CaptureState{"cap0": {State: []byte("some captured state")}},
+			map[string]types.CapturedState{"cap0": {State: []byte("some captured state")}},
 			[]byte("some state"),
 		)
 		assert.NoError(t, err)
@@ -59,7 +59,7 @@ func testNoCacheAndState(t *testing.T) {
 		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
 		result, err := capCtrl.Resolve(
 			map[string]string{"cap0": "my expression"},
-			map[string]types.CaptureState{},
+			map[string]types.CapturedState{},
 			[]byte{},
 		)
 		assert.NoError(t, err)
@@ -70,7 +70,7 @@ func testNoCacheAndState(t *testing.T) {
 
 func testAllCapturesCached(t *testing.T) {
 	t.Run("resolve with all captures cached", func(t *testing.T) {
-		capCache := map[string]types.CaptureState{
+		capCache := map[string]types.CapturedState{
 			"cap0": {State: []byte("some captured state")},
 			"cap1": {State: []byte("another captured state")},
 		}
@@ -97,12 +97,12 @@ func testResolvingExpressions(t *testing.T) {
 		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
 		result, err := capCtrl.Resolve(
 			map[string]string{capID: "my expression"},
-			map[string]types.CaptureState{},
+			map[string]types.CapturedState{},
 			[]byte("some state"),
 		)
 		assert.NoError(t, err)
 
-		assert.Equal(t, map[string]types.CaptureState{capID: {State: []byte("resolver: parser: lexer: my expression")}}, result.CapturedStates())
+		assert.Equal(t, map[string]types.CapturedState{capID: {State: []byte("resolver: parser: lexer: my expression")}}, result.CapturedStates())
 	})
 }
 
@@ -111,7 +111,7 @@ func testExpressionsWithPartialCache(t *testing.T) {
 		const capID0 = "cap0"
 		const capID1 = "cap1"
 
-		capCache := map[string]types.CaptureState{capID0: {State: []byte("some captured state")}}
+		capCache := map[string]types.CapturedState{capID0: {State: []byte("some captured state")}}
 		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
 
 		result, err := capCtrl.Resolve(
@@ -125,7 +125,7 @@ func testExpressionsWithPartialCache(t *testing.T) {
 		assert.NoError(t, err)
 
 		expectedCaps := capCache
-		expectedCaps[capID1] = types.CaptureState{State: []byte("resolver: parser: lexer: another expression")}
+		expectedCaps[capID1] = types.CapturedState{State: []byte("resolver: parser: lexer: another expression")}
 		assert.Equal(t, expectedCaps, result.CapturedStates())
 	})
 }
@@ -135,7 +135,7 @@ func testExpressionsWithOverCache(t *testing.T) {
 		const capID0 = "cap0"
 		const capID1 = "cap1"
 
-		capCache := map[string]types.CaptureState{
+		capCache := map[string]types.CapturedState{
 			capID0: {State: []byte("some captured state")},
 			capID1: {State: []byte("another captured state")},
 		}
@@ -150,7 +150,7 @@ func testExpressionsWithOverCache(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
-		expectedCaps := map[string]types.CaptureState{
+		expectedCaps := map[string]types.CapturedState{
 			capID0: {State: []byte("some captured state")},
 		}
 		assert.Equal(t, expectedCaps, result.CapturedStates())
@@ -162,7 +162,7 @@ func testLexFailure(t *testing.T) {
 		capCtrl := capture.New(lexerStub{failLex: true}, parserStub{}, resolverStub{})
 		_, err := capCtrl.Resolve(
 			map[string]string{"cap0": "my expression"},
-			map[string]types.CaptureState{},
+			map[string]types.CapturedState{},
 			[]byte("some state"),
 		)
 		assert.Error(t, err)
@@ -174,7 +174,7 @@ func testParseFailure(t *testing.T) {
 		capCtrl := capture.New(lexerStub{}, parserStub{failParse: true}, resolverStub{})
 		_, err := capCtrl.Resolve(
 			map[string]string{"cap0": "my expression"},
-			map[string]types.CaptureState{},
+			map[string]types.CapturedState{},
 			[]byte("some state"),
 		)
 		assert.Error(t, err)
@@ -186,7 +186,7 @@ func testResolveFailure(t *testing.T) {
 		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{failResolve: true})
 		_, err := capCtrl.Resolve(
 			map[string]string{"cap0": "my expression"},
-			map[string]types.CaptureState{},
+			map[string]types.CapturedState{},
 			[]byte("some state"),
 		)
 		assert.Error(t, err)

--- a/nmpolicy/internal/capture/capture_test.go
+++ b/nmpolicy/internal/capture/capture_test.go
@@ -17,15 +17,11 @@
 package capture_test
 
 import (
-	"fmt"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 
-	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
-	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
-	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
 	"github.com/nmstate/nmpolicy/nmpolicy/types"
 )
 
@@ -195,53 +191,4 @@ func testResolveFailure(t *testing.T) {
 		)
 		assert.Error(t, err)
 	})
-}
-
-type lexerStub struct {
-	failLex bool
-}
-
-func (l lexerStub) Lex(expression string) ([]lexer.Token, error) {
-	if l.failLex {
-		return nil, fmt.Errorf("lex failed")
-	}
-	literal := fmt.Sprintf("lexer: %s", expression)
-	return []lexer.Token{{Literal: literal}}, nil
-}
-
-type parserStub struct {
-	failParse bool
-}
-
-func (p parserStub) Parse(tokens []lexer.Token) (ast.Node, error) {
-	if p.failParse {
-		return ast.Node{}, fmt.Errorf("parse failed")
-	}
-	literal := fmt.Sprintf("parser: %s", tokens[0].Literal)
-	return ast.Node{Terminal: ast.Terminal{String: &literal}}, nil
-}
-
-type resolverStub struct {
-	failResolve bool
-}
-
-func (r resolverStub) Resolve(astPool map[string]ast.Node, state []byte) (resolver.Result, error) {
-	if r.failResolve {
-		return resolver.Result{}, fmt.Errorf("resolve failed")
-	}
-
-	capsState := map[string]types.CaptureState{}
-	for id, entry := range astPool {
-		capsState[id] = types.CaptureState{State: []byte(fmt.Sprintf("resolver: %s", *entry.String))}
-	}
-
-	return resolver.Result{Marshaled: capsState}, nil
-}
-
-func (r resolverStub) ResolveCaptureEntryPath(captureEntryPathAST ast.Node,
-	capturedStates map[string]map[string]interface{}) (interface{}, error) {
-	if r.failResolve {
-		return nil, fmt.Errorf("resolve capture entry path failed")
-	}
-	return fmt.Sprintf("resolver: %s", *captureEntryPathAST.String), nil
 }

--- a/nmpolicy/internal/capture/resolver.go
+++ b/nmpolicy/internal/capture/resolver.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nmstate/nmpolicy/nmpolicy/types"
 )
 
-type Capture struct {
+type CaptureResolver struct {
 	lexer    Lexer
 	parser   Parser
 	resolver Resolver
@@ -44,15 +44,15 @@ type Resolver interface {
 	ResolveCaptureEntryPath(captureEntryPathAST ast.Node, capturdStates map[string]map[string]interface{}) (interface{}, error)
 }
 
-func New(l Lexer, p Parser, r Resolver) Capture {
-	return Capture{
+func NewResolver(l Lexer, p Parser, r Resolver) CaptureResolver {
+	return CaptureResolver{
 		lexer:    l,
 		parser:   p,
 		resolver: r,
 	}
 }
 
-func (c Capture) Resolve(
+func (c CaptureResolver) Resolve(
 	capturesExpr map[string]string,
 	capturesCache map[string]types.CapturedState,
 	state []byte) (Result, error) {

--- a/nmpolicy/internal/capture/resolver_test.go
+++ b/nmpolicy/internal/capture/resolver_test.go
@@ -92,68 +92,70 @@ func testAllCapturesCached(t *testing.T) {
 
 func testResolvingExpressions(t *testing.T) {
 	t.Run("resolve expressions", func(t *testing.T) {
-		const capID = "cap0"
+		const captureEntryName = "cap0"
 
 		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
 		result, err := captureResolver.Resolve(
-			map[string]string{capID: "my expression"},
+			map[string]string{captureEntryName: "my expression"},
 			map[string]types.CapturedState{},
 			[]byte("some state"),
 		)
 		assert.NoError(t, err)
 
-		assert.Equal(t, map[string]types.CapturedState{capID: {State: []byte("resolver: parser: lexer: my expression")}}, result.CapturedStates())
+		assert.Equal(t, map[string]types.CapturedState{
+			captureEntryName: {State: []byte("resolver: parser: lexer: my expression")},
+		}, result.CapturedStates())
 	})
 }
 
 func testExpressionsWithPartialCache(t *testing.T) {
 	t.Run("resolve with expressions and partial cache", func(t *testing.T) {
-		const capID0 = "cap0"
-		const capID1 = "cap1"
+		const captureEntryName0 = "cap0"
+		const captureEntryName1 = "cap1"
 
-		capCache := map[string]types.CapturedState{capID0: {State: []byte("some captured state")}}
+		capturedStatesCache := map[string]types.CapturedState{captureEntryName0: {State: []byte("some captured state")}}
 		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
 
 		result, err := captureResolver.Resolve(
 			map[string]string{
-				capID0: "my expression",
-				capID1: "another expression",
+				captureEntryName0: "my expression",
+				captureEntryName1: "another expression",
 			},
-			capCache,
+			capturedStatesCache,
 			[]byte("some state"),
 		)
 		assert.NoError(t, err)
 
-		expectedCaps := capCache
-		expectedCaps[capID1] = types.CapturedState{State: []byte("resolver: parser: lexer: another expression")}
-		assert.Equal(t, expectedCaps, result.CapturedStates())
+		expectedCapturedStates := capturedStatesCache
+		expectedCapturedStates[captureEntryName1] = types.CapturedState{State: []byte("resolver: parser: lexer: another expression")}
+		assert.Equal(t, expectedCapturedStates, result.CapturedStates())
 	})
 }
 
 func testExpressionsWithOverCache(t *testing.T) {
 	t.Run("resolve with cache that is not included in the expressions", func(t *testing.T) {
-		const capID0 = "cap0"
-		const capID1 = "cap1"
+		const captureEntryName0 = "cap0"
+		const captureEntryName1 = "cap1"
 
-		capCache := map[string]types.CapturedState{
-			capID0: {State: []byte("some captured state")},
-			capID1: {State: []byte("another captured state")},
+		capturedStatesCache := map[string]types.CapturedState{
+			captureEntryName0: {State: []byte("some captured state")},
+			captureEntryName1: {State: []byte("another captured state")},
 		}
 		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
 
 		result, err := captureResolver.Resolve(
 			map[string]string{
-				capID0: "my expression",
+				captureEntryName0: "my expression",
 			},
-			capCache,
+			capturedStatesCache,
 			[]byte("some state"),
 		)
 		assert.NoError(t, err)
 
-		expectedCaps := map[string]types.CapturedState{
-			capID0: {State: []byte("some captured state")},
+		expectedCapturedStates := map[string]types.CapturedState{
+			captureEntryName0: {State: []byte("some captured state")},
 		}
-		assert.Equal(t, expectedCaps, result.CapturedStates())
+		assert.Equal(t, expectedCapturedStates, result.CapturedStates())
 	})
 }
 

--- a/nmpolicy/internal/capture/resolver_test.go
+++ b/nmpolicy/internal/capture/resolver_test.go
@@ -42,8 +42,8 @@ func TestBasicPolicy(t *testing.T) {
 
 func testNoExpressions(t *testing.T) {
 	t.Run("resolve with no expression", func(t *testing.T) {
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		result, err := capCtrl.Resolve(
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
+		result, err := captureResolver.Resolve(
 			map[string]string{},
 			map[string]types.CapturedState{"cap0": {State: []byte("some captured state")}},
 			[]byte("some state"),
@@ -56,8 +56,8 @@ func testNoExpressions(t *testing.T) {
 
 func testNoCacheAndState(t *testing.T) {
 	t.Run("resolve with no cache and state", func(t *testing.T) {
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		result, err := capCtrl.Resolve(
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
+		result, err := captureResolver.Resolve(
 			map[string]string{"cap0": "my expression"},
 			map[string]types.CapturedState{},
 			[]byte{},
@@ -75,8 +75,8 @@ func testAllCapturesCached(t *testing.T) {
 			"cap1": {State: []byte("another captured state")},
 		}
 
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		result, err := capCtrl.Resolve(
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
+		result, err := captureResolver.Resolve(
 			map[string]string{
 				"cap0": "my expression",
 				"cap1": "another expression",
@@ -94,8 +94,8 @@ func testResolvingExpressions(t *testing.T) {
 	t.Run("resolve expressions", func(t *testing.T) {
 		const capID = "cap0"
 
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
-		result, err := capCtrl.Resolve(
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
+		result, err := captureResolver.Resolve(
 			map[string]string{capID: "my expression"},
 			map[string]types.CapturedState{},
 			[]byte("some state"),
@@ -112,9 +112,9 @@ func testExpressionsWithPartialCache(t *testing.T) {
 		const capID1 = "cap1"
 
 		capCache := map[string]types.CapturedState{capID0: {State: []byte("some captured state")}}
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
 
-		result, err := capCtrl.Resolve(
+		result, err := captureResolver.Resolve(
 			map[string]string{
 				capID0: "my expression",
 				capID1: "another expression",
@@ -139,9 +139,9 @@ func testExpressionsWithOverCache(t *testing.T) {
 			capID0: {State: []byte("some captured state")},
 			capID1: {State: []byte("another captured state")},
 		}
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{})
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{})
 
-		result, err := capCtrl.Resolve(
+		result, err := captureResolver.Resolve(
 			map[string]string{
 				capID0: "my expression",
 			},
@@ -159,8 +159,8 @@ func testExpressionsWithOverCache(t *testing.T) {
 
 func testLexFailure(t *testing.T) {
 	t.Run("resolve fails due to lexing", func(t *testing.T) {
-		capCtrl := capture.New(lexerStub{failLex: true}, parserStub{}, resolverStub{})
-		_, err := capCtrl.Resolve(
+		captureResolver := capture.NewResolver(lexerStub{failLex: true}, parserStub{}, resolverStub{})
+		_, err := captureResolver.Resolve(
 			map[string]string{"cap0": "my expression"},
 			map[string]types.CapturedState{},
 			[]byte("some state"),
@@ -171,8 +171,8 @@ func testLexFailure(t *testing.T) {
 
 func testParseFailure(t *testing.T) {
 	t.Run("resolve fails due to parsing", func(t *testing.T) {
-		capCtrl := capture.New(lexerStub{}, parserStub{failParse: true}, resolverStub{})
-		_, err := capCtrl.Resolve(
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{failParse: true}, resolverStub{})
+		_, err := captureResolver.Resolve(
 			map[string]string{"cap0": "my expression"},
 			map[string]types.CapturedState{},
 			[]byte("some state"),
@@ -183,8 +183,8 @@ func testParseFailure(t *testing.T) {
 
 func testResolveFailure(t *testing.T) {
 	t.Run("resolve fails due to resolving", func(t *testing.T) {
-		capCtrl := capture.New(lexerStub{}, parserStub{}, resolverStub{failResolve: true})
-		_, err := capCtrl.Resolve(
+		captureResolver := capture.NewResolver(lexerStub{}, parserStub{}, resolverStub{failResolve: true})
+		_, err := captureResolver.Resolve(
 			map[string]string{"cap0": "my expression"},
 			map[string]types.CapturedState{},
 			[]byte("some state"),

--- a/nmpolicy/internal/capture/result.go
+++ b/nmpolicy/internal/capture/result.go
@@ -16,13 +16,20 @@
 
 package capture
 
-import "github.com/nmstate/nmpolicy/nmpolicy/types"
+import (
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
+	"github.com/nmstate/nmpolicy/nmpolicy/types"
+)
 
-type CaptureEntry struct {
-	CaptureCache map[string]types.CaptureState
+type Result struct {
+	resolverResult resolver.Result
 }
 
-func (c CaptureEntry) ResolveCaptureEntryPath(
+func (r Result) ResolveCaptureEntryPath(
 	capturePath string) (interface{}, error) {
 	return nil, nil
+}
+
+func (r Result) CapturedStates() map[string]types.CaptureState {
+	return r.resolverResult.Marshaled
 }

--- a/nmpolicy/internal/capture/result.go
+++ b/nmpolicy/internal/capture/result.go
@@ -58,6 +58,6 @@ func (r Result) ResolveCaptureEntryPath(captureEntryPathExpression string) (inte
 	return resolvedCaptureEntryPath, nil
 }
 
-func (r Result) CapturedStates() map[string]types.CaptureState {
+func (r Result) CapturedStates() map[string]types.CapturedState {
 	return r.resolverResult.Marshaled
 }

--- a/nmpolicy/internal/capture/result_test.go
+++ b/nmpolicy/internal/capture/result_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
+)
+
+func TestCaptureResolverResult(t *testing.T) {
+	t.Run("CaptureResolver result", func(t *testing.T) {
+		testResolveCaptureEntryPathSuccess(t)
+
+		testResolveCaptureEntryPathWithLexFailure(t)
+		testResolveCaptureEntryPathWithParseFailure(t)
+		testResolveCaptureEntryPathWithResolveFailure(t)
+	})
+}
+
+func testResolveCaptureEntryPathSuccess(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath success", func(t *testing.T) {
+		result := capture.NewResult(lexerStub{}, parserStub{}, resolverStub{}, resolver.Result{})
+		obtainedValue, err := result.ResolveCaptureEntryPath("my expression")
+		assert.NoError(t, err)
+		assert.Equal(t, "resolver: parser: lexer: my expression", obtainedValue)
+	})
+}
+
+func testResolveCaptureEntryPathWithLexFailure(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath lex failure", func(t *testing.T) {
+		result := capture.NewResult(lexerStub{failLex: true}, parserStub{}, resolverStub{}, resolver.Result{})
+		_, err := result.ResolveCaptureEntryPath("my expression")
+		assert.Error(t, err)
+	})
+}
+
+func testResolveCaptureEntryPathWithParseFailure(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath parser failure", func(t *testing.T) {
+		result := capture.NewResult(lexerStub{}, parserStub{failParse: true}, resolverStub{}, resolver.Result{})
+		_, err := result.ResolveCaptureEntryPath("my expression")
+		assert.Error(t, err)
+	})
+}
+
+func testResolveCaptureEntryPathWithResolveFailure(t *testing.T) {
+	t.Run("ResolveCaptureEntryPath resolver failure", func(t *testing.T) {
+		result := capture.NewResult(lexerStub{}, parserStub{}, resolverStub{failResolve: true}, resolver.Result{})
+		_, err := result.ResolveCaptureEntryPath("my expression")
+		assert.Error(t, err)
+	})
+}

--- a/nmpolicy/internal/capture/stub_test.go
+++ b/nmpolicy/internal/capture/stub_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture_test
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
+	"github.com/nmstate/nmpolicy/nmpolicy/types"
+)
+
+type lexerStub struct {
+	failLex bool
+}
+
+func (l lexerStub) Lex(expression string) ([]lexer.Token, error) {
+	if l.failLex {
+		return nil, fmt.Errorf("lex failed")
+	}
+	literal := fmt.Sprintf("lexer: %s", expression)
+	return []lexer.Token{{Literal: literal}}, nil
+}
+
+type parserStub struct {
+	failParse bool
+}
+
+func (p parserStub) Parse(tokens []lexer.Token) (ast.Node, error) {
+	if p.failParse {
+		return ast.Node{}, fmt.Errorf("parse failed")
+	}
+	literal := fmt.Sprintf("parser: %s", tokens[0].Literal)
+	return ast.Node{Terminal: ast.Terminal{String: &literal}}, nil
+}
+
+type resolverStub struct {
+	failResolve bool
+}
+
+func (r resolverStub) Resolve(astPool map[string]ast.Node, state []byte) (resolver.Result, error) {
+	if r.failResolve {
+		return resolver.Result{}, fmt.Errorf("resolve failed")
+	}
+
+	capsState := map[string]types.CaptureState{}
+	for id, entry := range astPool {
+		capsState[id] = types.CaptureState{State: []byte(fmt.Sprintf("resolver: %s", *entry.String))}
+	}
+
+	return resolver.Result{Marshaled: capsState}, nil
+}
+
+func (r resolverStub) ResolveCaptureEntryPath(captureEntryPathAST ast.Node,
+	capturedStates map[string]map[string]interface{}) (interface{}, error) {
+	if r.failResolve {
+		return nil, fmt.Errorf("resolve capture entry path failed")
+	}
+	return fmt.Sprintf("resolver: %s", *captureEntryPathAST.String), nil
+}

--- a/nmpolicy/internal/capture/stub_test.go
+++ b/nmpolicy/internal/capture/stub_test.go
@@ -58,9 +58,9 @@ func (r resolverStub) Resolve(astPool map[string]ast.Node, state []byte) (resolv
 		return resolver.Result{}, fmt.Errorf("resolve failed")
 	}
 
-	capsState := map[string]types.CaptureState{}
+	capsState := map[string]types.CapturedState{}
 	for id, entry := range astPool {
-		capsState[id] = types.CaptureState{State: []byte(fmt.Sprintf("resolver: %s", *entry.String))}
+		capsState[id] = types.CapturedState{State: []byte(fmt.Sprintf("resolver: %s", *entry.String))}
 	}
 
 	return resolver.Result{Marshaled: capsState}, nil

--- a/nmpolicy/internal/lexer/lexer.go
+++ b/nmpolicy/internal/lexer/lexer.go
@@ -24,19 +24,30 @@ import (
 )
 
 // Lexer struct is used to tokenize values returned by a reader.
+type Lexer struct{}
+
 type lexer struct {
 	scn *scanner.Scanner
 }
 
 // NewLexer construct a Lexer using reader as the input.
-func New() *lexer {
-	return &lexer{}
+func New() Lexer {
+	return Lexer{}
+}
+
+func newLexer(expression string) *lexer {
+	return &lexer{scn: scanner.New(strings.NewReader(expression))}
 }
 
 // Lex scans the input for the next token.
 // It returns a Token struct with position, type, and the literal value.
-func (l *lexer) Lex(expression string) ([]Token, error) {
-	l.scn = scanner.New(strings.NewReader(expression))
+func (Lexer) Lex(expression string) ([]Token, error) {
+	return newLexer(expression).Lex()
+}
+
+// Lex scans the input for the next token.
+// It returns a Token struct with position, type, and the literal value.
+func (l *lexer) Lex() ([]Token, error) {
 	// keep looping until we return a token
 	tokens := []Token{}
 	for {

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -253,7 +253,7 @@ func runTest(t *testing.T, tests []test) {
 	}
 }
 
-func runTestWithParser(t *testing.T, testToRun test, p *parser.Parser) {
+func runTestWithParser(t *testing.T, testToRun test, p parser.Parser) {
 	obtainedAST, obtainedErr := p.Parse(testToRun.tokens)
 	if testToRun.expected.err != "" {
 		assert.EqualError(t, obtainedErr, testToRun.expected.err)

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -73,7 +73,7 @@ func (r *resolver) Resolve(currentState []byte) (Result, error) {
 	}
 
 	result := Result{
-		Marshaled:   map[string]types.CaptureState{},
+		Marshaled:   map[string]types.CapturedState{},
 		Unmarshaled: map[string]map[string]interface{}{},
 	}
 	for captureEntryName := range r.captureASTPool {
@@ -85,7 +85,7 @@ func (r *resolver) Resolve(currentState []byte) (Result, error) {
 		if err != nil {
 			return Result{}, wrapWithResolveError(err)
 		}
-		result.Marshaled[captureEntryName] = types.CaptureState{
+		result.Marshaled[captureEntryName] = types.CapturedState{
 			State:    marshaledCapturedStateEntry,
 			MetaInfo: types.MetaInfo{},
 		}

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -38,15 +38,32 @@ func New() Resolver {
 }
 
 func (Resolver) Resolve(captureASTPool map[string]ast.Node, currentState []byte) (Result, error) {
-	return newResolver(captureASTPool).Resolve(currentState)
+	return newWithCaptureASTPool(captureASTPool).Resolve(currentState)
 }
 
-func newResolver(captureASTPool map[string]ast.Node) *resolver {
+func (Resolver) ResolveCaptureEntryPath(captureEntryPathAST ast.Node,
+	capturedStates map[string]map[string]interface{}) (interface{}, error) {
+	return newWithCapturedStates(capturedStates).ResolveCaptureEntryPath(captureEntryPathAST)
+}
+
+func newEmpty() *resolver {
 	return &resolver{
 		currentState:   map[string]interface{}{},
 		capturedStates: map[string]map[string]interface{}{},
-		captureASTPool: captureASTPool,
+		captureASTPool: map[string]ast.Node{},
 	}
+}
+
+func newWithCaptureASTPool(captureASTPool map[string]ast.Node) *resolver {
+	r := newEmpty()
+	r.captureASTPool = captureASTPool
+	return r
+}
+
+func newWithCapturedStates(capturedStates map[string]map[string]interface{}) *resolver {
+	r := newEmpty()
+	r.capturedStates = capturedStates
+	return r
 }
 
 func (r *resolver) Resolve(currentState []byte) (Result, error) {

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -64,6 +64,10 @@ func (r *Resolver) Resolve(captureASTPool map[string]ast.Node, currentState []by
 	return capturedStates, nil
 }
 
+func (r *Resolver) ResolveCaptureEntryPath(captureEntryPath ast.Node) (interface{}, error) {
+	return r.resolveCaptureEntryPath(captureEntryPath)
+}
+
 func (r *Resolver) resolveCaptureEntryName(captureEntryName string) (map[string]interface{}, error) {
 	capturedStateEntry, ok := r.capturedStates[captureEntryName]
 	if ok {

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -88,15 +88,16 @@ func runTest(t *testing.T, testToRun test) {
 	resolver := newResolver(astPool)
 	resolver.capturedStates = capturedStates
 
-	resultStates, err := resolver.Resolve([]byte(sourceYAML))
+	obtainedResult, err := resolver.Resolve([]byte(sourceYAML))
 	if testToRun.err == "" {
 		assert.NoError(t, err)
 		expectedState := make(map[string]interface{})
 		actualState := make(map[string]interface{})
 		for captureName, expectedYaml := range testToRun.expectedYamls {
 			assert.NoError(t, yaml.Unmarshal([]byte(expectedYaml), &expectedState))
-			assert.NoError(t, yaml.Unmarshal(resultStates[captureName].State, &actualState))
+			assert.NoError(t, yaml.Unmarshal(obtainedResult.Marshaled[captureName].State, &actualState))
 			assert.Equal(t, expectedState, actualState)
+			assert.Equal(t, expectedState, obtainedResult.Unmarshaled[captureName])
 		}
 	} else {
 		assert.EqualError(t, err, testToRun.err)

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -85,10 +85,10 @@ func runTest(t *testing.T, testToRun test) {
 
 	capturedStates, err := unmarshalCapturedState(testToRun.capturedStates)
 	assert.NoError(t, err)
-	resolver := New()
+	resolver := newResolver(astPool)
 	resolver.capturedStates = capturedStates
 
-	resultStates, err := resolver.Resolve(astPool, []byte(sourceYAML))
+	resultStates, err := resolver.Resolve([]byte(sourceYAML))
 	if testToRun.err == "" {
 		assert.NoError(t, err)
 		expectedState := make(map[string]interface{})

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -85,7 +85,7 @@ func runTest(t *testing.T, testToRun test) {
 
 	capturedStates, err := unmarshalCapturedState(testToRun.capturedStates)
 	assert.NoError(t, err)
-	resolver := newResolver(astPool)
+	resolver := newWithCaptureASTPool(astPool)
 	resolver.capturedStates = capturedStates
 
 	obtainedResult, err := resolver.Resolve([]byte(sourceYAML))

--- a/nmpolicy/internal/resolver/result.go
+++ b/nmpolicy/internal/resolver/result.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import "github.com/nmstate/nmpolicy/nmpolicy/types"
+
+type Result struct {
+	Unmarshaled map[string]map[string]interface{}
+	Marshaled   map[string]types.CaptureState
+}

--- a/nmpolicy/internal/resolver/result.go
+++ b/nmpolicy/internal/resolver/result.go
@@ -20,5 +20,5 @@ import "github.com/nmstate/nmpolicy/nmpolicy/types"
 
 type Result struct {
 	Unmarshaled map[string]map[string]interface{}
-	Marshaled   map[string]types.CaptureState
+	Marshaled   map[string]types.CapturedState
 }

--- a/nmpolicy/internal/state/expander.go
+++ b/nmpolicy/internal/state/expander.go
@@ -24,15 +24,15 @@ import (
 )
 
 type Expander struct {
-	capResolver CapturePathResolver
+	captureEntryPathResolver CaptureEntryPathResolver
 }
 
-type CapturePathResolver interface {
+type CaptureEntryPathResolver interface {
 	ResolveCaptureEntryPath(capturePath string) (interface{}, error)
 }
 
-func NewExpander(capResolver CapturePathResolver) Expander {
-	return Expander{capResolver: capResolver}
+func NewExpander(captureEntryPathResolver CaptureEntryPathResolver) Expander {
+	return Expander{captureEntryPathResolver: captureEntryPathResolver}
 }
 
 func (c Expander) Expand(marshaledDesiredState []byte) ([]byte, error) {
@@ -115,7 +115,7 @@ func (c Expander) expandString(stringState string) (interface{}, error) {
 	}
 
 	capturePath := submatch[1]
-	resolvedPath, err := c.capResolver.ResolveCaptureEntryPath(capturePath)
+	resolvedPath, err := c.captureEntryPathResolver.ResolveCaptureEntryPath(capturePath)
 
 	if err != nil {
 		return nil, err

--- a/nmpolicy/internal/state/expander_test.go
+++ b/nmpolicy/internal/state/expander_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package expander
+package state
 
 import (
 	"fmt"
@@ -80,7 +80,7 @@ routes:
 		pathResults: map[string]interface{}{"capture.base-iface.interfaces[0].ipv4": "1.2.3.4", "capture.base-iface.interfaces[0].name": "eth1",
 			"capture.bridge-routes-takeover.running": unmarshaledRoutes},
 	}
-	expandedState, err := New(capturerStub).Expand([]byte(desiredState))
+	expandedState, err := NewExpander(capturerStub).Expand([]byte(desiredState))
 	assert.NoError(t, err)
 	verifyResult(t, expectedExandedState, expandedState)
 }
@@ -108,7 +108,7 @@ func TestExpanderCaptureIsTopLevel(t *testing.T) {
 	capturerStub := pathCapturerStub{failResolve: false,
 		pathResults: map[string]interface{}{"capture.base-iface": unmarshaledInterfaces},
 	}
-	expandedState, err := New(capturerStub).Expand([]byte(desiredState))
+	expandedState, err := NewExpander(capturerStub).Expand([]byte(desiredState))
 	assert.NoError(t, err)
 	verifyResult(t, expectedExandedState, expandedState)
 }
@@ -118,7 +118,7 @@ func TestExpanderResolveCaptureFails(t *testing.T) {
 "{{ capture.enabled-iface }}"
 `
 	capturerStub := pathCapturerStub{failResolve: true}
-	expandedState, err := New(capturerStub).Expand([]byte(desiredState))
+	expandedState, err := NewExpander(capturerStub).Expand([]byte(desiredState))
 
 	assert.Error(t, err)
 	assert.Nil(t, expandedState)

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -48,13 +48,13 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 		desiredState = append(desiredState, nmpolicy.DesiredState...)
 
 		capResolver := capture.New(lexer.New(), parser.New(), resolver.New())
-		var err error
-		capturesState, err = capResolver.Resolve(nmpolicy.Capture, cache.Capture, currentState)
+		resolverResult, err := capResolver.Resolve(nmpolicy.Capture, cache.Capture, currentState)
 		if err != nil {
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
 		}
+		capturesState = resolverResult.CapturedStates()
 
-		stateExpander := expander.New(capture.CaptureEntry{CaptureCache: capturesState})
+		stateExpander := expander.New(resolverResult)
 		desiredState, err = stateExpander.Expand(desiredState)
 		if err != nil {
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -48,7 +48,7 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 		desiredState = append(desiredState, nmpolicy.DesiredState...)
 
 		capResolver := capture.NewResolver(lexer.New(), parser.New(), resolver.New())
-		resolverResult, err := capResolver.Resolve(nmpolicy.Capture, cache.Capture, currentState)
+		resolverResult, err := capResolver.Resolve(nmpolicy.Capture, cache.CapturedStates, currentState)
 		if err != nil {
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
 		}
@@ -64,7 +64,7 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 	timestamp := time.Now().UTC()
 	timestampCapturesState(capturesState, timestamp)
 	return types.GeneratedState{
-		Cache:        types.CachedState{Capture: capturesState},
+		Cache:        types.CachedState{CapturedStates: capturesState},
 		DesiredState: desiredState,
 		MetaInfo: types.MetaInfo{
 			Version:   "0",

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -41,7 +41,7 @@ import (
 //
 // On failure, an error is returned.
 func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.CachedState) (types.GeneratedState, error) {
-	var capturesState map[string]types.CaptureState
+	var capturesState map[string]types.CapturedState
 	var desiredState []byte
 
 	if nmpolicy.DesiredState != nil {
@@ -73,7 +73,7 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 	}, nil
 }
 
-func timestampCapturesState(capturesState map[string]types.CaptureState, timeStamp time.Time) {
+func timestampCapturesState(capturesState map[string]types.CapturedState, timeStamp time.Time) {
 	for captureID, captureState := range capturesState {
 		if captureState.MetaInfo.TimeStamp.IsZero() {
 			captureState.MetaInfo.TimeStamp = timeStamp

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -21,10 +21,10 @@ import (
 	"time"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
-	"github.com/nmstate/nmpolicy/nmpolicy/internal/expander"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/state"
 	"github.com/nmstate/nmpolicy/nmpolicy/types"
 )
 
@@ -54,7 +54,7 @@ func GenerateState(policySpec types.PolicySpec, currentState []byte, cachedState
 		}
 		capturedStates = resolverResult.CapturedStates()
 
-		stateExpander := expander.New(resolverResult)
+		stateExpander := state.NewExpander(resolverResult)
 		desiredState, err = stateExpander.Expand(desiredState)
 		if err != nil {
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -47,7 +47,7 @@ func GenerateState(nmpolicy types.PolicySpec, currentState []byte, cache types.C
 	if nmpolicy.DesiredState != nil {
 		desiredState = append(desiredState, nmpolicy.DesiredState...)
 
-		capResolver := capture.New(lexer.New(), parser.New(), resolver.New())
+		capResolver := capture.NewResolver(lexer.New(), parser.New(), resolver.New())
 		resolverResult, err := capResolver.Resolve(nmpolicy.Capture, cache.Capture, currentState)
 		if err != nil {
 			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)

--- a/nmpolicy/types/types.go
+++ b/nmpolicy/types/types.go
@@ -24,7 +24,7 @@ type PolicySpec struct {
 }
 
 type CachedState struct {
-	Capture map[string]CaptureState
+	Capture map[string]CapturedState
 }
 
 type GeneratedState struct {
@@ -33,7 +33,7 @@ type GeneratedState struct {
 	MetaInfo     MetaInfo
 }
 
-type CaptureState struct {
+type CapturedState struct {
 	State    []byte
 	MetaInfo MetaInfo
 }

--- a/nmpolicy/types/types.go
+++ b/nmpolicy/types/types.go
@@ -24,7 +24,7 @@ type PolicySpec struct {
 }
 
 type CachedState struct {
-	Capture map[string]CapturedState
+	CapturedStates map[string]CapturedState
 }
 
 type GeneratedState struct {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -33,7 +33,7 @@ func TestBasicPolicy(t *testing.T) {
 		testEmptyPolicy(t)
 		testPolicyWithOnlyDesiredState(t)
 		testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t)
-		testPolicyWithFilterCaptureAndDesiredStateWithoutRef(t)
+		testPolicyWithFilterCaptureAndDesiredStateCaptureEntryRef(t)
 		testGenerateUniqueTimestamps(t)
 	})
 }
@@ -148,14 +148,51 @@ interfaces:
       enabled: true
 `)
 
-func testPolicyWithFilterCaptureAndDesiredStateWithoutRef(t *testing.T) {
+var mainDesiredState = []byte(`
+interfaces:
+- name: br1
+  description: Linux bridge with base interface as a port
+  type: linux-bridge
+  state: up
+  ipv4: "{{ capture.base-iface.interfaces.0.ipv4 }}"
+  bridge:
+    options:
+      stp:
+        enabled: false
+    port:
+    - name: "{{ capture.base-iface.interfaces.0.name }}"
+`)
+
+var mainExpectedDesiredState = []byte(`
+interfaces:
+- name: br1
+  description: Linux bridge with base interface as a port
+  type: linux-bridge
+  state: up
+  ipv4:
+    address:
+    - ip: 10.244.0.1
+      prefix-length: 24
+    - ip: 169.254.1.0
+      prefix-length: 16
+    dhcp: false
+    enabled: true
+  bridge:
+    options:
+      stp:
+        enabled: false
+    port:
+    - name: eth1
+`)
+
+func testPolicyWithFilterCaptureAndDesiredStateCaptureEntryRef(t *testing.T) {
 	t.Run("with a eqfilter capture expression and desired state that has no ref", func(t *testing.T) {
 		policySpec := types.PolicySpec{
 			Capture: map[string]string{
-				"default-gw":        `routes.running.destination=="0.0.0.0/0"`,
-				"base-iface-routes": `routes.running.next-hop-interface==capture.default-gw.routes.running.0.next-hop-interface`,
+				"default-gw": `routes.running.destination=="0.0.0.0/0"`,
+				"base-iface": `interfaces.name==capture.default-gw.routes.running.0.next-hop-interface`,
 			},
-			DesiredState: mainCurrentState,
+			DesiredState: mainDesiredState,
 		}
 		obtained, err := nmpolicy.GenerateState(
 			policySpec,
@@ -167,7 +204,7 @@ func testPolicyWithFilterCaptureAndDesiredStateWithoutRef(t *testing.T) {
 			MetaInfo: types.MetaInfo{
 				Version: "0",
 			},
-			DesiredState: mainCurrentState,
+			DesiredState: mainExpectedDesiredState,
 			Cache: types.CachedState{
 				Capture: map[string]types.CaptureState{
 					"default-gw": {
@@ -180,18 +217,20 @@ routes:
     table-id: 254
 `),
 					},
-					"base-iface-routes": {
+					"base-iface": {
 						State: []byte(`
-routes:  
-  running:
-  - destination: 0.0.0.0/0
-    next-hop-address: 192.168.100.1
-    next-hop-interface: eth1
-    table-id: 254
-  - destination: 1.1.1.0/24
-    next-hop-address: 192.168.100.1
-    next-hop-interface: eth1
-    table-id: 254
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: 10.244.0.1
+      prefix-length: 24
+    - ip: 169.254.1.0
+      prefix-length: 16
+    dhcp: false
+    enabled: true
 `),
 					},
 				},

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -84,7 +84,7 @@ func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 		}
 
 		cacheState := types.CachedState{
-			Capture: map[string]types.CapturedState{capID0: {State: []byte("some captured state")}},
+			CapturedStates: map[string]types.CapturedState{capID0: {State: []byte("some captured state")}},
 		}
 		s, err := nmpolicy.GenerateState(
 			policySpec,
@@ -206,7 +206,7 @@ func testPolicyWithFilterCaptureAndDesiredStateCaptureEntryRef(t *testing.T) {
 			},
 			DesiredState: mainExpectedDesiredState,
 			Cache: types.CachedState{
-				Capture: map[string]types.CapturedState{
+				CapturedStates: map[string]types.CapturedState{
 					"default-gw": {
 						State: []byte(`
 routes:
@@ -269,7 +269,7 @@ func testGenerateUniqueTimestamps(t *testing.T) {
 			DesiredState: stateData,
 		}
 		cacheState := types.CachedState{
-			Capture: map[string]types.CapturedState{
+			CapturedStates: map[string]types.CapturedState{
 				capID1: {
 					State: []byte("{}"),
 					MetaInfo: types.MetaInfo{
@@ -285,30 +285,30 @@ func testGenerateUniqueTimestamps(t *testing.T) {
 			stateData,
 			cacheState)
 		assert.NoError(t, err)
-		assert.Equal(t, obtained.MetaInfo.TimeStamp, obtained.Cache.Capture[capID0].MetaInfo.TimeStamp)
-		assert.Equal(t, cacheState.Capture[capID1].MetaInfo, obtained.Cache.Capture[capID1].MetaInfo)
+		assert.Equal(t, obtained.MetaInfo.TimeStamp, obtained.Cache.CapturedStates[capID0].MetaInfo.TimeStamp)
+		assert.Equal(t, cacheState.CapturedStates[capID1].MetaInfo, obtained.Cache.CapturedStates[capID1].MetaInfo)
 		assert.Greater(t, obtained.MetaInfo.TimeStamp.Sub(beforeGenerate), time.Duration(0))
-		assert.Greater(t, obtained.Cache.Capture[capID0].MetaInfo.TimeStamp.Sub(beforeGenerate), time.Duration(0))
+		assert.Greater(t, obtained.Cache.CapturedStates[capID0].MetaInfo.TimeStamp.Sub(beforeGenerate), time.Duration(0))
 	})
 }
 
 func resetTimeStamp(generatedState types.GeneratedState) types.GeneratedState {
 	generatedState.MetaInfo.TimeStamp = time.Time{}
-	for captureID, captureState := range generatedState.Cache.Capture {
+	for captureID, captureState := range generatedState.Cache.CapturedStates {
 		captureState.MetaInfo.TimeStamp = time.Time{}
-		generatedState.Cache.Capture[captureID] = captureState
+		generatedState.Cache.CapturedStates[captureID] = captureState
 	}
 	return generatedState
 }
 
 func formatYAMLs(generatedState types.GeneratedState) (types.GeneratedState, error) {
-	for captureID, captureState := range generatedState.Cache.Capture {
+	for captureID, captureState := range generatedState.Cache.CapturedStates {
 		formatedYAML, err := formatYAML(captureState.State)
 		if err != nil {
 			return types.GeneratedState{}, err
 		}
 		captureState.State = formatedYAML
-		generatedState.Cache.Capture[captureID] = captureState
+		generatedState.Cache.CapturedStates[captureID] = captureState
 	}
 	formatedDesiredState, err := formatYAML(generatedState.DesiredState)
 	if err != nil {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -84,7 +84,7 @@ func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 		}
 
 		cacheState := types.CachedState{
-			Capture: map[string]types.CaptureState{capID0: {State: []byte("some captured state")}},
+			Capture: map[string]types.CapturedState{capID0: {State: []byte("some captured state")}},
 		}
 		s, err := nmpolicy.GenerateState(
 			policySpec,
@@ -206,7 +206,7 @@ func testPolicyWithFilterCaptureAndDesiredStateCaptureEntryRef(t *testing.T) {
 			},
 			DesiredState: mainExpectedDesiredState,
 			Cache: types.CachedState{
-				Capture: map[string]types.CaptureState{
+				Capture: map[string]types.CapturedState{
 					"default-gw": {
 						State: []byte(`
 routes:
@@ -269,7 +269,7 @@ func testGenerateUniqueTimestamps(t *testing.T) {
 			DesiredState: stateData,
 		}
 		cacheState := types.CachedState{
-			Capture: map[string]types.CaptureState{
+			Capture: map[string]types.CapturedState{
 				capID1: {
 					State: []byte("{}"),
 					MetaInfo: types.MetaInfo{


### PR DESCRIPTION
Change code according to the following name conventions:

- `capture` policy spec field:
   - `map[string]string`: is`captureExpressions`, key is `captureEntryName` and value is `captureEntryExpression`
   - `map[string][]lexer.Token`: is `captureTokens`, key is `captureEntryName` and value is `captureEntryTokens`
   - `map[string]ast.Node`: is `captureASTPool`, key is `captureEntryName` and value is `captureEntryASTPool`
- The result from resolving `capture` field is `capturedStates`, key is `captureEntryName` and value is `capturedState`

It also contains some extra name fixing not related to the conventions.

Depends on:
- https://github.com/nmstate/nmpolicy/pull/37
 