### PR TITLE
devel: Add Makefile wrapper around make.sh

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -46,7 +46,7 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Build cmd
-      run: ./scripts/make.sh --build
+      run: make build
   unit-test:
     name: unit test 
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Run unit tests
-      run: ./scripts/make.sh --unit-test
+      run: make unit-test
   integration-test:
     name: integration-test
     runs-on: ubuntu-latest
@@ -70,4 +70,4 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Run tests
-      run: ./scripts/make.sh --integration-test
+      run: make integration-test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all build lint unit-test integration-test
+
+CMD=./scripts/make.sh
+
+all:
+	$(CMD)
+
+build: 
+	$(CMD)  --build
+
+lint:
+	$(CMD) --lint
+
+unit-test: 
+	$(CMD) --unit-test
+
+integration-test:
+	$(CMD) --unit-test


### PR DESCRIPTION
Having a Makefile at top project make easy for new comers and distro
packagers to follow how to build/lint/test the project. This change add
a Makefile wrapping the targets at ./scripts/make.sh.

