### PR TITLE
[tech debt] internal, types: Use unmarshaled structs at the internal package.

### DIFF
--- a/cmd/nmpolicy/main.go
+++ b/cmd/nmpolicy/main.go
@@ -22,7 +22,10 @@ import (
 )
 
 func main() {
-	_, err := nmpolicy.GenerateState(types.PolicySpec{}, nil, types.CachedState{})
+	policySpec := types.PolicySpec{}
+	cachedState := types.CachedState{}
+	currentState := []byte{}
+	_, err := nmpolicy.GenerateState(policySpec, currentState, cachedState)
 	if err != nil {
 		panic(err)
 	}

--- a/nmpolicy/internal/capture/capture_entry.go
+++ b/nmpolicy/internal/capture/capture_entry.go
@@ -22,31 +22,27 @@ import (
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
-	"github.com/nmstate/nmpolicy/nmpolicy/types"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
 )
 
 type CaptureEntry struct {
-	capturedStates map[string]map[string]interface{}
+	capturedStates types.CapturedStates
 	lexer          Lexer
 	parser         Parser
 	resolver       Resolver
 }
 
-func NewCaptureEntryWithLexerParserResolver(capturedStates map[string]types.CaptureState,
+func NewCaptureEntryWithLexerParserResolver(capturedStates types.CapturedStates,
 	l Lexer, p Parser, r Resolver) (CaptureEntry, error) {
-	unmarshaledCapturedStates, err := unmarshalCapturedStates(capturedStates)
-	if err != nil {
-		return CaptureEntry{}, err
-	}
 	return CaptureEntry{
-		capturedStates: unmarshaledCapturedStates,
+		capturedStates: capturedStates,
 		lexer:          l,
 		parser:         p,
 		resolver:       r,
 	}, nil
 }
 
-func NewCaptureEntry(capturedStates map[string]types.CaptureState) (CaptureEntry, error) {
+func NewCaptureEntry(capturedStates types.CapturedStates) (CaptureEntry, error) {
 	return NewCaptureEntryWithLexerParserResolver(capturedStates, lexer.New(), parser.New(), resolver.New())
 }
 

--- a/nmpolicy/internal/capture/capture_entry_test.go
+++ b/nmpolicy/internal/capture/capture_entry_test.go
@@ -22,7 +22,7 @@ import (
 	assert "github.com/stretchr/testify/require"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
-	"github.com/nmstate/nmpolicy/nmpolicy/types"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
 )
 
 func TestCaptureEntry(t *testing.T) {
@@ -37,7 +37,7 @@ func TestCaptureEntry(t *testing.T) {
 
 func testResolveCaptureEntryPathSuccess(t *testing.T) {
 	t.Run("ResolveCaptureEntryPath success", func(t *testing.T) {
-		capturedStates := map[string]types.CaptureState{}
+		capturedStates := types.CapturedStates{}
 		captureEntryResolver, err := captureEntryResolverWithDefaultStubs(capturedStates)
 		assert.NoError(t, err)
 		obtainedValue, err := captureEntryResolver.ResolveCaptureEntryPath("my expression")
@@ -48,7 +48,7 @@ func testResolveCaptureEntryPathSuccess(t *testing.T) {
 
 func testResolveCaptureEntryPathWithLexFailure(t *testing.T) {
 	t.Run("ResolveCaptureEntryPath lex failure", func(t *testing.T) {
-		capturedStates := map[string]types.CaptureState{}
+		capturedStates := types.CapturedStates{}
 		captureEntryResolver, err := capture.NewCaptureEntryWithLexerParserResolver(capturedStates,
 			lexerStub{failLex: true}, parserStub{}, resolverStub{})
 		assert.NoError(t, err)
@@ -59,7 +59,7 @@ func testResolveCaptureEntryPathWithLexFailure(t *testing.T) {
 
 func testResolveCaptureEntryPathWithParseFailure(t *testing.T) {
 	t.Run("ResolveCaptureEntryPath parser failure", func(t *testing.T) {
-		capturedStates := map[string]types.CaptureState{}
+		capturedStates := types.CapturedStates{}
 		captureEntryResolver, err := capture.NewCaptureEntryWithLexerParserResolver(capturedStates,
 			lexerStub{}, parserStub{failParse: true}, resolverStub{})
 		assert.NoError(t, err)
@@ -70,7 +70,7 @@ func testResolveCaptureEntryPathWithParseFailure(t *testing.T) {
 
 func testResolveCaptureEntryPathWithResolveFailure(t *testing.T) {
 	t.Run("ResolveCaptureEntryPath resolver failure", func(t *testing.T) {
-		capturedStates := map[string]types.CaptureState{}
+		capturedStates := types.CapturedStates{}
 		captureEntryResolver, err := capture.NewCaptureEntryWithLexerParserResolver(capturedStates,
 			lexerStub{}, parserStub{}, resolverStub{failResolve: true})
 		assert.NoError(t, err)
@@ -79,6 +79,6 @@ func testResolveCaptureEntryPathWithResolveFailure(t *testing.T) {
 	})
 }
 
-func captureEntryResolverWithDefaultStubs(capturedStates map[string]types.CaptureState) (capture.CaptureEntry, error) {
+func captureEntryResolverWithDefaultStubs(capturedStates types.CapturedStates) (capture.CaptureEntry, error) {
 	return capture.NewCaptureEntryWithLexerParserResolver(capturedStates, lexerStub{}, parserStub{}, resolverStub{})
 }

--- a/nmpolicy/internal/operations.go
+++ b/nmpolicy/internal/operations.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expander"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
+)
+
+func GenerateState(policySpec types.PolicySpec, currentState types.NMState, cachedState types.CachedState) (types.GeneratedState, error) {
+	var (
+		capturedStates types.CapturedStates
+		desiredState   types.NMState
+	)
+
+	if policySpec.DesiredState != nil {
+		capResolver := capture.New(lexer.New(), parser.New(), resolver.New())
+		var err error
+		capturedStates, err = capResolver.Resolve(policySpec.Capture, cachedState.CapturedStates, currentState)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
+
+		captureEntryPathResolver, err := capture.NewCaptureEntry(capturedStates)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
+
+		stateExpander := expander.New(captureEntryPathResolver)
+		desiredState, err = stateExpander.Expand(policySpec.DesiredState)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
+	}
+
+	timestamp := time.Now().UTC()
+	timestampCapturesState(capturedStates, timestamp)
+	return types.GeneratedState{
+		Cache:        types.CachedState{CapturedStates: capturedStates},
+		DesiredState: desiredState,
+		MetaInfo: nmpolicytypes.MetaInfo{
+			Version:   "0",
+			TimeStamp: timestamp,
+		},
+	}, nil
+}
+
+func timestampCapturesState(capturedStates types.CapturedStates, timeStamp time.Time) {
+	for captureID, capturedState := range capturedStates {
+		if capturedState.MetaInfo.TimeStamp.IsZero() {
+			capturedState.MetaInfo.TimeStamp = timeStamp
+			capturedStates[captureID] = capturedState
+		}
+	}
+}

--- a/nmpolicy/internal/types/types.go
+++ b/nmpolicy/internal/types/types.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
+)
+
+type NMState map[string]interface{}
+type CaptureExpressions map[string]string
+type CapturedStates map[string]CapturedState
+type CaptureASTPool map[string]ast.Node
+
+type PolicySpec struct {
+	Capture      CaptureExpressions
+	DesiredState NMState
+}
+
+type CachedState struct {
+	CapturedStates CapturedStates
+}
+
+type GeneratedState struct {
+	Cache        CachedState
+	DesiredState NMState
+	MetaInfo     nmpolicytypes.MetaInfo
+}
+
+type CapturedState struct {
+	State    NMState
+	MetaInfo nmpolicytypes.MetaInfo
+}

--- a/nmpolicy/internal/types/typestest/typestest.go
+++ b/nmpolicy/internal/types/typestest/typestest.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package typestest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "sigs.k8s.io/yaml"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+)
+
+func ToNMState(t *testing.T, marshaled string) (nmState types.NMState) {
+	assert.NoError(t, yaml.Unmarshal([]byte(marshaled), &nmState))
+	return nmState
+}
+
+func ToIface(t *testing.T, marshaled string) (iface interface{}) {
+	assert.NoError(t, yaml.Unmarshal([]byte(marshaled), &iface))
+	return iface
+}
+
+func ToCapturedStates(t *testing.T, marshaled string) (capturedStates types.CapturedStates) {
+	assert.NoError(t, yaml.Unmarshal([]byte(marshaled), &capturedStates))
+	return capturedStates
+}
+
+func ToCaptureASTPool(t *testing.T, marshaled string) (captureASTPool types.CaptureASTPool) {
+	assert.NoError(t, yaml.Unmarshal([]byte(marshaled), &captureASTPool))
+	return captureASTPool
+}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -55,14 +55,14 @@ func testPolicyWithOnlyDesiredState(t *testing.T) {
 	// When a basic input with only the desired state is provided,
 	// the policy just passes it as is to the output with no modifications.
 	t.Run("with only desired state", func(t *testing.T) {
-		stateData := []byte(`this is not a legal yaml format!
-`)
+		stateData := []byte("name: test state")
+		stateData, err := typestest.FormatYAML(stateData)
+		assert.NoError(t, err)
 		policySpec := types.PolicySpec{
 			DesiredState: stateData,
 		}
 
 		s, err := nmpolicy.GenerateState(policySpec, nil, types.NoCache())
-
 		assert.NoError(t, err)
 		expectedState := types.GeneratedState{
 			DesiredState: stateData,
@@ -74,8 +74,9 @@ func testPolicyWithOnlyDesiredState(t *testing.T) {
 
 func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 	t.Run("with all captures cached and desired state that has no ref", func(t *testing.T) {
-		stateData := []byte(`this is not a legal yaml format!
-`)
+		stateData := []byte("name: test state")
+		stateData, err := typestest.FormatYAML(stateData)
+		assert.NoError(t, err)
 		const capID0 = "cap0"
 		policySpec := types.PolicySpec{
 			Capture: map[string]string{
@@ -87,7 +88,6 @@ func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 		cacheState := types.CachedState{
 			Capture: map[string]types.CaptureState{capID0: {State: []byte("name: some captured state")}},
 		}
-		var err error
 		cacheState.Capture, err = formatCapturedStates(cacheState.Capture)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Current implementation do a lot of marshaling/unmarshaling from yaml at different levels of the code mixing it with the logic, this change make internal package agnostico to YAML/JSON format by using the unmarshaled version of it represented by some internal types.

The PR has being splited into different commits to make review easier but they are not suppose to pass "make".