### PR TITLE
cli: Import nmpolicy into cmd

### DIFF
--- a/cmd/nmpolicy/main.go
+++ b/cmd/nmpolicy/main.go
@@ -16,8 +16,14 @@
 
 package main
 
-import "fmt"
+import (
+	"github.com/nmstate/nmpolicy/nmpolicy"
+	"github.com/nmstate/nmpolicy/nmpolicy/types"
+)
 
 func main() {
-	fmt.Println("vim-go")
+	_, err := nmpolicy.GenerateState(types.PolicySpec{}, nil, types.CachedState{})
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
To compile the nmpolicy library when we compile the cli this change
import nmpolicy and do dummy call to GenerateState.

Signed-off-by: Quique Llorente <ellorent@redhat.com>