### PR TITLE
parser, resolver: Implement Replace operator :=

### DIFF
--- a/nmpolicy/internal/ast/types.go
+++ b/nmpolicy/internal/ast/types.go
@@ -31,6 +31,7 @@ type Terminal struct {
 type Node struct {
 	Meta
 	EqFilter *TernaryOperator  `json:"eqfilter,omitempty"`
+	Replace  *TernaryOperator  `json:"replace,omitempty"`
 	Path     *VariadicOperator `json:"path,omitempty"`
 	Terminal
 }

--- a/nmpolicy/internal/parser/errors.go
+++ b/nmpolicy/internal/parser/errors.go
@@ -65,6 +65,13 @@ func invalidEqualityFilterError(msg string) *parserError {
 	}
 }
 
+func invalidReplaceError(msg string) *parserError {
+	return &parserError{
+		prefix: "invalid replace",
+		msg:    msg,
+	}
+}
+
 func invalidExpressionError(msg string) *parserError {
 	return &parserError{
 		prefix: "invalid expression",

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -29,12 +29,19 @@ import (
 )
 
 func TestParser(t *testing.T) {
-	testParseFailures(t)
-	testParseSuccess(t)
+	testParsePath(t)
+	testParseEqFilter(t)
+	testParseReplace(t)
+
+	testParseBasicFailures(t)
+	testParsePathFailures(t)
+	testParseEqFilterFailure(t)
+	testParseReplaceFailure(t)
+
 	testParserReuse(t)
 }
 
-func testParseFailures(t *testing.T) {
+func testParseBasicFailures(t *testing.T) {
 	var tests = []test{
 		expectError("invalid expression: unexpected token `.`",
 			fromTokens(
@@ -42,6 +49,12 @@ func testParseFailures(t *testing.T) {
 				eof(),
 			),
 		),
+	}
+	runTest(t, tests)
+}
+
+func testParsePathFailures(t *testing.T) {
+	var tests = []test{
 		expectError(`invalid path: missing identity or number after dot`,
 			fromTokens(
 				identity("routes"),
@@ -65,6 +78,12 @@ func testParseFailures(t *testing.T) {
 				eof(),
 			),
 		),
+	}
+	runTest(t, tests)
+}
+
+func testParseEqFilterFailure(t *testing.T) {
+	var tests = []test{
 		expectError(`invalid equality filter: missing left hand argument`,
 			fromTokens(
 				eqfilter(),
@@ -80,6 +99,18 @@ func testParseFailures(t *testing.T) {
 				eof(),
 			),
 		),
+		expectError(`invalid equality filter: missing right hand argument`,
+			fromTokens(
+				identity("routes"),
+				dot(),
+				identity("running"),
+				dot(),
+				identity("destination"),
+				eqfilter(),
+				eof(),
+			),
+		),
+
 		expectError(`invalid equality filter: right hand argument is not a string or identity`,
 			fromTokens(
 				identity("routes"),
@@ -96,7 +127,52 @@ func testParseFailures(t *testing.T) {
 	runTest(t, tests)
 }
 
-func testParseSuccess(t *testing.T) {
+func testParseReplaceFailure(t *testing.T) {
+	var tests = []test{
+		expectError(`invalid replace: missing left hand argument`,
+			fromTokens(
+				replace(),
+				str("0.0.0.0/0"),
+				eof(),
+			),
+		),
+		expectError(`invalid replace: left hand argument is not a path`,
+			fromTokens(
+				str("foo"),
+				replace(),
+				str("0.0.0.0/0"),
+				eof(),
+			),
+		),
+		expectError(`invalid replace: missing right hand argument`,
+			fromTokens(
+				identity("routes"),
+				dot(),
+				identity("running"),
+				dot(),
+				identity("destination"),
+				replace(),
+				eof(),
+			),
+		),
+
+		expectError(`invalid replace: right hand argument is not a string`,
+			fromTokens(
+				identity("routes"),
+				dot(),
+				identity("running"),
+				dot(),
+				identity("destination"),
+				replace(),
+				replace(),
+				eof(),
+			),
+		),
+	}
+	runTest(t, tests)
+}
+
+func testParsePath(t *testing.T) {
 	var tests = []test{
 		expectEmptyAST(fromTokens()),
 		expectAST(t, `
@@ -117,6 +193,12 @@ path:
 				eof(),
 			),
 		),
+	}
+	runTest(t, tests)
+}
+
+func testParseEqFilter(t *testing.T) {
+	var tests = []test{
 		expectAST(t, `
 pos: 26
 eqfilter: 
@@ -185,6 +267,39 @@ eqfilter:
 				number(0),
 				dot(),
 				identity("next-hop-interface"),
+				eof(),
+			),
+		),
+	}
+	runTest(t, tests)
+}
+
+func testParseReplace(t *testing.T) {
+	var tests = []test{
+		expectAST(t, `
+pos: 33
+replace:
+- pos: 0
+  identity: currentState
+- pos: 0 
+  path: 
+  - pos: 0 
+    identity: routes
+  - pos: 7
+    identity: running
+  - pos: 15
+    identity: next-hop-interface
+- pos: 35
+  string: br1
+`,
+			fromTokens(
+				identity("routes"),
+				dot(),
+				identity("running"),
+				dot(),
+				identity("next-hop-interface"),
+				replace(),
+				str("br1"),
 				eof(),
 			),
 		),
@@ -331,4 +446,8 @@ func eof() lexer.Token {
 
 func eqfilter() lexer.Token {
 	return lexer.Token{Type: lexer.EQFILTER, Literal: "=="}
+}
+
+func replace() lexer.Token {
+	return lexer.Token{Type: lexer.REPLACE, Literal: ":="}
 }

--- a/nmpolicy/internal/resolver/errors.go
+++ b/nmpolicy/internal/resolver/errors.go
@@ -29,3 +29,11 @@ func wrapWithResolveError(err error) error {
 func wrapWithEqFilterError(err error) error {
 	return fmt.Errorf("eqfilter error: %v", err)
 }
+
+func replaceError(format string, a ...interface{}) error {
+	return wrapWithReplaceError(fmt.Errorf(format, a...))
+}
+
+func wrapWithReplaceError(err error) error {
+	return fmt.Errorf("replace error: %v", err)
+}

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -23,7 +23,7 @@ import (
 )
 
 func filter(inputState map[string]interface{}, path ast.VariadicOperator, expectedNode ast.Node) (map[string]interface{}, error) {
-	filtered, err := applyFuncOnPath(inputState, path, expectedNode, mapContainsValue, true)
+	filtered, err := applyFuncOnMap(path, inputState, expectedNode, mapContainsValue, true, true)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed applying operation on the path: %v", err)

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func replace(inputState map[string]interface{}, path ast.VariadicOperator, expectedNode ast.Node) (map[string]interface{}, error) {
+	replaced, err := applyFuncOnMap(path, inputState, expectedNode, replaceMapFieldValue, false, false)
+
+	if err != nil {
+		return nil, replaceError("failed applying operation on the path: %v", err)
+	}
+
+	replacedMap, ok := replaced.(map[string]interface{})
+	if !ok {
+		return nil, replaceError("failed converting result to a map")
+	}
+	return replacedMap, nil
+}
+
+func replaceMapFieldValue(inputMap map[string]interface{}, mapEntryKeyToReplace string, expectedNode ast.Node) (interface{}, error) {
+	if expectedNode.String == nil {
+		return false, replaceError("the desired value %+v is not supported. Curretly only string values are supported", expectedNode)
+	}
+	modifiedMap := map[string]interface{}{}
+	for k, v := range inputMap {
+		modifiedMap[k] = v
+	}
+
+	modifiedMap[mapEntryKeyToReplace] = *expectedNode.String
+	return modifiedMap, nil
+}


### PR DESCRIPTION
For the main scenario NMPolicy need to resolve `capture.base-iface-routes | routes.running.next-hop-interface:="br1"` part of this expression is the replace operator `:=` this PR implement that operator at parser and resolver and also allow filter/replace to use a capture ref path as input so next PR implementing the pipe will involve only the parser.

Thech debt:
- For apply functions at `nmpolicy/internal/path.go`:
  - Use a struct so func and flags does not need to be passed around
  - The expectedNode argument is not needed to be passed if we function to apply is a closure containing it.
 