### PR TITLE
 resolver: Implement pipe with capture and replace

### DIFF
--- a/nmpolicy/internal/lexer/token.go
+++ b/nmpolicy/internal/lexer/token.go
@@ -24,12 +24,14 @@ const (
 	NUMBER
 	STRING
 
-	DOT  // .
-	PIPE // |
+	DOT // .
 
+	operatorsBegin
+	PIPE     // |
 	REPLACE  // :=
 	EQFILTER // ==
 	MERGE    // +
+	operatorsEnd
 
 	TRUE  // true
 	FALSE // false
@@ -54,6 +56,10 @@ var tokens = []string{
 
 func (t TokenType) String() string {
 	return tokens[t]
+}
+
+func (t TokenType) IsOperator() bool {
+	return t > operatorsBegin && t < operatorsEnd
 }
 
 type Token struct {

--- a/nmpolicy/internal/parser/errors.go
+++ b/nmpolicy/internal/parser/errors.go
@@ -78,3 +78,10 @@ func invalidExpressionError(msg string) *parserError {
 		msg:    msg,
 	}
 }
+
+func invalidPipeError(msg string) *parserError {
+	return &parserError{
+		prefix: "invalid pipe",
+		msg:    msg,
+	}
+}

--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -31,6 +31,7 @@ type parser struct {
 	tokens          []lexer.Token
 	currentTokenIdx int
 	lastNode        *ast.Node
+	pipedInNode     *ast.Node
 }
 
 func New() Parser {
@@ -75,15 +76,26 @@ func (p *parser) parse() (ast.Node, error) {
 			if err := p.parseReplace(); err != nil {
 				return ast.Node{}, err
 			}
+		} else if p.currentToken().Type == lexer.PIPE {
+			if err := p.parsePipe(); err != nil {
+				return ast.Node{}, err
+			}
 		} else {
 			return ast.Node{}, invalidExpressionError(fmt.Sprintf("unexpected token `%+v`", p.currentToken().Literal))
 		}
 		p.nextToken()
 	}
-	if p.lastNode == nil {
-		return ast.Node{}, nil
+	if p.pipedInNode != nil {
+		return ast.Node{}, invalidPipeError("missing pipe out expression")
 	}
-	return *p.lastNode, nil
+	return p.lastEmitedNode(), nil
+}
+
+func (p *parser) lastEmitedNode() ast.Node {
+	if p.lastNode == nil {
+		return ast.Node{}
+	}
+	return *p.lastNode
 }
 
 func (p *parser) nextToken() {
@@ -169,7 +181,7 @@ func (p *parser) parsePath() error {
 			}
 			path := append(*operator.Path, *p.lastNode)
 			operator.Path = &path
-		} else if p.currentToken().Type != lexer.EOF && p.currentToken().Type != lexer.EQFILTER && p.currentToken().Type != lexer.REPLACE {
+		} else if p.currentToken().Type != lexer.EOF && !p.currentToken().Type.IsOperator() {
 			return invalidPathError("missing dot")
 		} else {
 			// Token has not being consumed let's go back.
@@ -192,7 +204,9 @@ func (p *parser) parseEqFilter() error {
 	if p.lastNode.Path == nil {
 		return invalidEqualityFilterError("left hand argument is not a path")
 	}
-	operator.EqFilter[0].Terminal = ast.CurrentStateIdentity()
+
+	p.fillInPipedInOrCurrentState(&operator.EqFilter[0])
+
 	operator.EqFilter[1] = *p.lastNode
 
 	p.nextToken()
@@ -228,7 +242,9 @@ func (p *parser) parseReplace() error {
 	if p.lastNode.Path == nil {
 		return invalidReplaceError("left hand argument is not a path")
 	}
-	operator.Replace[0].Terminal = ast.CurrentStateIdentity()
+
+	p.fillInPipedInOrCurrentState(&operator.Replace[0])
+
 	operator.Replace[1] = *p.lastNode
 
 	p.nextToken()
@@ -243,5 +259,25 @@ func (p *parser) parseReplace() error {
 		return invalidReplaceError("right hand argument is not a string")
 	}
 	p.lastNode = operator
+	return nil
+}
+
+func (p *parser) fillInPipedInOrCurrentState(node *ast.Node) {
+	if p.pipedInNode != nil {
+		*node = *p.pipedInNode
+		p.pipedInNode = nil
+	} else {
+		node.Terminal = ast.CurrentStateIdentity()
+	}
+}
+
+func (p *parser) parsePipe() error {
+	if p.lastNode == nil {
+		return invalidPipeError("missing pipe in expression")
+	}
+	if p.lastNode.Path == nil {
+		return invalidPipeError("only paths can be piped in")
+	}
+	p.pipedInNode = p.lastNode
 	return nil
 }


### PR DESCRIPTION
For the main scenario we have an expression like [1] this expression
uses a capture reference path as pipe in and a replace expression as
pipe out. This change convert pipe as the first argument on the ternary
replace operation.
  
[1] capture.base-iface-routes | routes.running.next-hop-interface:="br1"
