### PR TITLE
infra: Add a goreleaser mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ vendor/
 # IDEs, editor's
 .idea
 .sw*
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    main: ./cmd/nmpolicy
+archives:
+  - replacements:
+      linux: Linux
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
The project will need to release also some binaries for the cli, this
change add a goreleaser mechanism to release nmpolicy with nice
changelog to github.

Signed-off-by: Quique Llorente <ellorent@redhat.com>