### PR TITLE
parser: Return empty if there is no tokens

### DIFF
--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -103,6 +103,9 @@ func (p *parser) prevToken() {
 }
 
 func (p *parser) currentToken() *lexer.Token {
+	if len(p.tokens) == 0 || p.currentTokenIdx >= len(p.tokens) {
+		return nil
+	}
 	return &p.tokens[p.currentTokenIdx]
 }
 

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -98,6 +98,7 @@ func testParseFailures(t *testing.T) {
 
 func testParseSuccess(t *testing.T) {
 	var tests = []test{
+		expectEmptyAST(fromTokens()),
 		expectAST(t, `
 pos: 0
 path:
@@ -295,6 +296,11 @@ func expectAST(t *testing.T, astYAML string, tst test) test {
 	err := yaml.Unmarshal([]byte(astYAML), a)
 	assert.NoError(t, err)
 	tst.expected.ast = a
+	return tst
+}
+
+func expectEmptyAST(tst test) test {
+	tst.expected.ast = &ast.Node{}
 	return tst
 }
 


### PR DESCRIPTION
If a user pass an empty expression parser do an illegal access to the
tokens list, this change add a test and a fix to mimic this scenario.