### PR TITLE
cli: Implement main using pflag

### DIFF
--- a/cmd/nmpolicy/main.go
+++ b/cmd/nmpolicy/main.go
@@ -17,16 +17,89 @@
 package main
 
 import (
+	"fmt"
+	"log"
+	"os"
+
+	flag "github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+
 	"github.com/nmstate/nmpolicy/nmpolicy"
 	"github.com/nmstate/nmpolicy/nmpolicy/types"
 )
 
+var (
+	policyPath               string
+	currentStatePath         string
+	capturedStatesInputPath  string
+	capturedStatesOutputPath string
+	desiredStatePath         string
+	help                     bool
+)
+
 func main() {
-	policySpec := types.PolicySpec{}
-	cachedState := types.CachedState{}
-	currentState := []byte{}
-	_, err := nmpolicy.GenerateState(policySpec, currentState, cachedState)
-	if err != nil {
-		panic(err)
+	flag.StringVar(&policyPath, "policy", "policy.yaml", "input file path to NNPolicy")
+	flag.StringVar(&currentStatePath, "current-state", "current-state.yaml", "input file path to current NMState")
+	flag.StringVar(&capturedStatesInputPath, "captured-states-input", "captured-states-input.yaml",
+		"input file path to the captured NMStates from previous run")
+	flag.StringVar(&desiredStatePath, "desired-state", "desired-state.yaml", "output file for the generated NMState")
+	flag.StringVar(&capturedStatesOutputPath, "captured-states-output", "captured-states-output.yaml",
+		"output file path to the captured NMStates from previous run")
+	flag.BoolVarP(&help, "help", "h", false, "")
+
+	flag.Parse()
+
+	if help {
+		flag.Usage()
 	}
+
+	policy := types.PolicySpec{}
+	if err := unmarshalFromPath(policyPath, &policy); err != nil {
+		log.Fatalf("failed reading policy: %v", err)
+	}
+	capturedStatesInput := types.CachedState{}
+	if err := unmarshalFromPath(capturedStatesInputPath, &capturedStatesInput); err != nil {
+		log.Fatalf("failed reading captured states: %v", err)
+	}
+
+	currentState, err := os.ReadFile(currentStatePath)
+	if err != nil {
+		log.Fatalf("failed reading current state: %v", err)
+	}
+
+	generatedState, err := nmpolicy.GenerateState(policy, currentState, capturedStatesInput)
+	if err != nil {
+		log.Fatalf("failed generating desired state: %v", err)
+	}
+
+	if err := marshalToPath(desiredStatePath, generatedState.DesiredState); err != nil {
+		log.Fatalf("failed writing desired state: %v", err)
+	}
+
+	if err := marshalToPath(capturedStatesOutputPath, generatedState.Cache); err != nil {
+		log.Fatalf("failed writing captured states: %v", err)
+	}
+}
+
+func unmarshalFromPath(path string, unmarshaled interface{}) error {
+	marshaled, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed reading file to unmarshal it: %w", err)
+	}
+
+	if err := yaml.Unmarshal(marshaled, unmarshaled); err != nil {
+		return fmt.Errorf("failed unmarshaling %s: %w", path, err)
+	}
+	return nil
+}
+
+func marshalToPath(path string, unmarshaled interface{}) error {
+	marshaled, err := yaml.Marshal(unmarshaled)
+	if err != nil {
+		return fmt.Errorf("failed marshaling %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, marshaled, 0); err != nil {
+		return fmt.Errorf("failed writing file with marshaled data: %w", err)
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nmstate/nmpolicy
 go 1.16
 
 require (
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
The nmpolicy should implement at cli that is able to generate a
desiredState from a NMPolicy. This change implement just that using the
library https://github.com/spf13/pflag to parse the arguments.