### PR TITLE
parser: Don't panic on single eof token

### DIFF
--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -76,6 +76,9 @@ func (p *parser) parse() (ast.Node, error) {
 		}
 		p.nextToken()
 	}
+	if p.lastNode == nil {
+		return ast.Node{}, nil
+	}
 	return *p.lastNode, nil
 }
 

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -99,6 +99,7 @@ func testParseFailures(t *testing.T) {
 func testParseSuccess(t *testing.T) {
 	var tests = []test{
 		expectEmptyAST(fromTokens()),
+		expectEmptyAST(fromTokens(eof())),
 		expectAST(t, `
 pos: 0
 path:


### PR DESCRIPTION
When the expressin is empty the lexer will return a slice of tokens with
just one EOF, there is a bug at parser that throws a panic trying to
access the last token. This change add the guard to prevent that.

Signed-off-by: Quique Llorente <ellorent@redhat.com>

/kind bug
/area lib