### PR TITLE
lexer, parser: Decorate errors with expression snippet.

### DIFF
--- a/nmpolicy/internal/capture/capture.go
+++ b/nmpolicy/internal/capture/capture.go
@@ -35,7 +35,7 @@ type Lexer interface {
 }
 
 type Parser interface {
-	Parse([]lexer.Token) (ast.Node, error)
+	Parse(string, []lexer.Token) (ast.Node, error)
 }
 
 type Resolver interface {
@@ -69,7 +69,7 @@ func (c Capture) Resolve(
 			return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
 		}
 
-		astRoot, err := c.parser.Parse(tokens)
+		astRoot, err := c.parser.Parse(capExpr, tokens)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
 		}

--- a/nmpolicy/internal/capture/capture.go
+++ b/nmpolicy/internal/capture/capture.go
@@ -39,8 +39,9 @@ type Parser interface {
 }
 
 type Resolver interface {
-	Resolve(captureASTPool types.CaptureASTPool, state types.NMState, capturedStates types.CapturedStates) (types.CapturedStates, error)
-	ResolveCaptureEntryPath(captureEntryPathAST ast.Node, capturedStates types.CapturedStates) (interface{}, error)
+	Resolve(captureExpressions types.CaptureExpressions, captureASTPool types.CaptureASTPool,
+		state types.NMState, capturedStates types.CapturedStates) (types.CapturedStates, error)
+	ResolveCaptureEntryPath(expression string, captureEntryPathAST ast.Node, capturedStates types.CapturedStates) (interface{}, error)
 }
 
 func New(leXer Lexer, parser Parser, resolver Resolver) Capture {
@@ -77,7 +78,7 @@ func (c Capture) Resolve(
 		astPool[capID] = astRoot
 	}
 
-	resolvedCapturedStates, err := c.resolver.Resolve(astPool, state, capturesState)
+	resolvedCapturedStates, err := c.resolver.Resolve(capturesExpr, astPool, state, capturesState)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
 	}

--- a/nmpolicy/internal/capture/capture_entry.go
+++ b/nmpolicy/internal/capture/capture_entry.go
@@ -53,7 +53,7 @@ func (c CaptureEntry) ResolveCaptureEntryPath(
 		return nil, fmt.Errorf("failed to resolve capture entry path expression: %v", err)
 	}
 
-	captureEntryPathAST, err := c.parser.Parse(captureEntryPathTokens)
+	captureEntryPathAST, err := c.parser.Parse(captureEntryPathExpression, captureEntryPathTokens)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve capture entry path expression: %v", err)
 	}

--- a/nmpolicy/internal/capture/capture_entry.go
+++ b/nmpolicy/internal/capture/capture_entry.go
@@ -58,7 +58,7 @@ func (c CaptureEntry) ResolveCaptureEntryPath(
 		return nil, fmt.Errorf("failed to resolve capture entry path expression: %v", err)
 	}
 
-	resolvedCaptureEntryPath, err := c.resolver.ResolveCaptureEntryPath(captureEntryPathAST, c.capturedStates)
+	resolvedCaptureEntryPath, err := c.resolver.ResolveCaptureEntryPath(captureEntryPathExpression, captureEntryPathAST, c.capturedStates)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve capture entry path expression: %v", err)
 	}

--- a/nmpolicy/internal/capture/stubs_test.go
+++ b/nmpolicy/internal/capture/stubs_test.go
@@ -56,7 +56,7 @@ type resolverStub struct {
 	failResolve bool
 }
 
-func (r resolverStub) Resolve(captureASTPool types.CaptureASTPool,
+func (r resolverStub) Resolve(captureExpressions types.CaptureExpressions, captureASTPool types.CaptureASTPool,
 	state types.NMState, capturedStates types.CapturedStates) (types.CapturedStates, error) {
 	if r.failResolve {
 		return nil, fmt.Errorf("resolve stub failed")
@@ -76,7 +76,7 @@ func (r resolverStub) Resolve(captureASTPool types.CaptureASTPool,
 	return capsState, nil
 }
 
-func (r resolverStub) ResolveCaptureEntryPath(captureEntryPathAST ast.Node,
+func (r resolverStub) ResolveCaptureEntryPath(expression string, captureEntryPathAST ast.Node,
 	capturedStates types.CapturedStates) (interface{}, error) {
 	if r.failResolve {
 		return nil, fmt.Errorf("resolve capture entry path failed")

--- a/nmpolicy/internal/capture/stubs_test.go
+++ b/nmpolicy/internal/capture/stubs_test.go
@@ -44,7 +44,7 @@ type parserStub struct {
 	failParse bool
 }
 
-func (p parserStub) Parse(tokens []lexer.Token) (ast.Node, error) {
+func (p parserStub) Parse(expression string, tokens []lexer.Token) (ast.Node, error) {
 	if p.failParse {
 		return ast.Node{}, fmt.Errorf("parse failed")
 	}

--- a/nmpolicy/internal/expression/error.go
+++ b/nmpolicy/internal/expression/error.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression
+
+import (
+	"fmt"
+)
+
+// WrapError construct a new error wrapping the error and decorating it
+// with the expression and a pointer at the position specified.
+func WrapError(err error, expression string, pos int) error {
+	return fmt.Errorf("%w\n%s", err, snippet(expression, pos))
+}
+
+// DecorateError construct a new error including the error and decorating it
+// with the expression and a pointer at the position specified.
+func DecorateError(err error, expression string, pos int) error {
+	return fmt.Errorf("%s\n%s", err, snippet(expression, pos))
+}

--- a/nmpolicy/internal/expression/error_test.go
+++ b/nmpolicy/internal/expression/error_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expression"
+)
+
+func TestError(t *testing.T) {
+	err := fmt.Errorf("test error")
+	wrappedError := expression.WrapError(err, "0123456", 4)
+	decoratedError := expression.DecorateError(err, "0123456", 4)
+	expectedErrorMsg := `test error
+| 0123456
+| ....^`
+	assert.EqualError(t, wrappedError, expectedErrorMsg)
+	assert.ErrorIs(t, wrappedError, err)
+	assert.EqualError(t, decoratedError, expectedErrorMsg)
+	assert.NotErrorIs(t, decoratedError, err)
+}

--- a/nmpolicy/internal/expression/snippet.go
+++ b/nmpolicy/internal/expression/snippet.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Snippet returns a string containing src and a pointer at pos.
+// Example of str "123456" and pos "4":
+//
+// | 123456
+// | ...^
+func snippet(expression string, pos int) string {
+	if expression == "" {
+		return ""
+	}
+
+	if pos >= len(expression) {
+		pos = len(expression) - 1
+	}
+
+	marker := strings.Builder{}
+	for i := 0; i < pos; i++ {
+		marker.WriteString(".")
+	}
+	marker.WriteString("^")
+	return fmt.Sprintf("| %s\n| %s", expression, marker.String())
+}

--- a/nmpolicy/internal/expression/snippet_test.go
+++ b/nmpolicy/internal/expression/snippet_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expression
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSource(t *testing.T) {
+	tests := []struct {
+		expression string
+		pos        int
+		snippet    string
+	}{
+		{"012345678", 5, `
+| 012345678
+| .....^`},
+		{"012345678", -3, `
+| 012345678
+| ^`},
+		{"012345678", 10, `
+| 012345678
+| ........^`},
+		{"", 10, `
+`},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("snippet of '%s' at '%d'", tt.expression, tt.pos), func(t *testing.T) {
+			snippet := "\n" + snippet(tt.expression, tt.pos)
+			assert.Equal(t, tt.snippet, snippet)
+		})
+	}
+}

--- a/nmpolicy/internal/lexer/lexer.go
+++ b/nmpolicy/internal/lexer/lexer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expression"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/scanner"
 )
 
@@ -27,7 +28,8 @@ import (
 type Lexer struct{}
 
 type lexer struct {
-	scn *scanner.Scanner
+	expression string
+	scn        *scanner.Scanner
 }
 
 // NewLexer construct a Lexer using reader as the input.
@@ -35,14 +37,14 @@ func New() Lexer {
 	return Lexer{}
 }
 
-func newLexer(expression string) *lexer {
-	return &lexer{scn: scanner.New(strings.NewReader(expression))}
+func newLexer(expr string) *lexer {
+	return &lexer{expression: expr, scn: scanner.New(strings.NewReader(expr))}
 }
 
 // Lex scans the input for the next token.
 // It returns a Token struct with position, type, and the literal value.
-func (Lexer) Lex(expression string) ([]Token, error) {
-	return newLexer(expression).Lex()
+func (Lexer) Lex(expr string) ([]Token, error) {
+	return newLexer(expr).Lex()
 }
 
 // Lex scans the input for the next token.
@@ -53,7 +55,7 @@ func (l *lexer) Lex() ([]Token, error) {
 	for {
 		token, err := l.lex()
 		if err != nil {
-			return nil, err
+			return nil, expression.WrapError(err, l.expression, l.scn.Position())
 		}
 		if token == nil {
 			continue

--- a/nmpolicy/internal/lexer/lexer_test.go
+++ b/nmpolicy/internal/lexer/lexer_test.go
@@ -127,40 +127,64 @@ func testFailures(t *testing.T) {
 	t.Run("failures", func(t *testing.T) {
 		runTest(t, []test{
 			{"foo=bar", expected{
-				err: "invalid EQFILTER operation format (b is not equal char)",
+				err: `invalid EQFILTER operation format (b is not equal char)
+| foo=bar
+| ....^`,
 			}},
 			{" foo 1foo ", expected{
-				err: "invalid number format (f is not a digit)",
+				err: `invalid number format (f is not a digit)
+|  foo 1foo 
+| ......^`,
 			}},
 			{" foo -foo ", expected{
-				err: "illegal rune -",
+				err: `illegal rune -
+|  foo -foo 
+| .....^`,
 			}},
 			{` "bar1" "foo dar`, expected{
-				err: `invalid string format (missing " terminator)`,
+				err: `invalid string format (missing " terminator)
+|  "bar1" "foo dar
+| ...............^`,
 			}},
 			{` "bar1" 'foo dar`, expected{
-				err: "invalid string format (missing ' terminator)",
+				err: `invalid string format (missing ' terminator)
+|  "bar1" 'foo dar
+| ...............^`,
 			}},
 			{"155 -44", expected{
-				err: "illegal rune -",
+				err: `illegal rune -
+| 155 -44
+| ....^`,
 			}},
 			{"255 1,3", expected{
-				err: "invalid number format (, is not a digit)",
+				err: `invalid number format (, is not a digit)
+| 255 1,3
+| .....^`,
 			}},
 			{"355 1e3", expected{
-				err: "invalid number format (e is not a digit)",
+				err: `invalid number format (e is not a digit)
+| 355 1e3
+| .....^`,
 			}},
 			{"455 0xEA", expected{
-				err: "invalid number format (x is not a digit)",
+				err: `invalid number format (x is not a digit)
+| 455 0xEA
+| .....^`,
 			}},
 			{"555 2,3-4", expected{
-				err: "invalid number format (, is not a digit)",
+				err: `invalid number format (, is not a digit)
+| 555 2,3-4
+| .....^`,
 			}},
 			{"655 3333_444_333", expected{
-				err: "invalid number format (_ is not a digit)",
+				err: `invalid number format (_ is not a digit)
+| 655 3333_444_333
+| ........^`,
 			}},
 			{"755 33 44 -.3", expected{
-				err: "illegal rune -",
+				err: `illegal rune -
+| 755 33 44 -.3
+| ..........^`,
 			}},
 		})
 	})

--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expression"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
 )
@@ -28,6 +29,7 @@ import (
 type Parser struct{}
 
 type parser struct {
+	expression      string
 	tokens          []lexer.Token
 	currentTokenIdx int
 	lastNode        *ast.Node
@@ -38,18 +40,18 @@ func New() Parser {
 	return Parser{}
 }
 
-func newParser(tokens []lexer.Token) *parser {
-	return &parser{tokens: tokens}
+func newParser(expr string, tokens []lexer.Token) *parser {
+	return &parser{expression: expr, tokens: tokens}
 }
 
-func (Parser) Parse(tokens []lexer.Token) (ast.Node, error) {
-	return newParser(tokens).Parse()
+func (Parser) Parse(expr string, tokens []lexer.Token) (ast.Node, error) {
+	return newParser(expr, tokens).Parse()
 }
 
 func (p *parser) Parse() (ast.Node, error) {
 	node, err := p.parse()
 	if err != nil {
-		return ast.Node{}, err
+		return ast.Node{}, expression.WrapError(err, p.expression, p.currentToken().Position)
 	}
 	return node, nil
 }

--- a/nmpolicy/internal/types/typestest/typestest.go
+++ b/nmpolicy/internal/types/typestest/typestest.go
@@ -35,6 +35,11 @@ func ToIface(t *testing.T, marshaled string) (iface interface{}) {
 	return iface
 }
 
+func ToCaptureExpressions(t *testing.T, marshaled string) (captureExpressions types.CaptureExpressions) {
+	assert.NoError(t, yaml.Unmarshal([]byte(marshaled), &captureExpressions))
+	return captureExpressions
+}
+
 func ToCapturedStates(t *testing.T, marshaled string) (capturedStates types.CapturedStates) {
 	assert.NoError(t, yaml.Unmarshal([]byte(marshaled), &capturedStates))
 	return capturedStates


### PR DESCRIPTION
At lexer, parser is easy to detect the rune, token that is generating
the error. This change wrap those errors with the expression and a
pointer.
    
Since the parser knows only about tokens, this change add also the
expression to the parser so it can use it to wrap the errors.

At resolver the ast.Node contains a Position field that points to the expressions
rune where the ast.Node was generated from. This change use that
position to to wrap the errors with a snippet that contains the
expression and a pointer to the place that generated the error.

To acomplish that the capture expressions are passed to the resolver so
it can search for the expression string to create the snippet.

The snippet pointer marks until operators but not inside the paths, this
can be fixed at a follow up.

The errors will look like:
```
invalid equality filter: right hand argument is not a string
| routes.running.destination==this.is.wrong                                     
| ............................^
```