### PR TITLE
replace, test: Add unit test to replace with cap

### DIFF
--- a/nmpolicy/internal/parser/errors.go
+++ b/nmpolicy/internal/parser/errors.go
@@ -58,17 +58,17 @@ func invalidPathError(msg string) *parserError {
 	}
 }
 
-func invalidEqualityFilterError(msg string) *parserError {
+func wrapWithInvalidEqualityFilterError(err error) *parserError {
 	return &parserError{
 		prefix: "invalid equality filter",
-		msg:    msg,
+		inner:  err,
 	}
 }
 
-func invalidReplaceError(msg string) *parserError {
+func wrapWithInvalidReplaceError(err error) *parserError {
 	return &parserError{
 		prefix: "invalid replace",
-		msg:    msg,
+		inner:  err,
 	}
 }
 

--- a/nmpolicy/internal/parser/parser_test.go
+++ b/nmpolicy/internal/parser/parser_test.go
@@ -32,6 +32,7 @@ func TestParser(t *testing.T) {
 	testParsePath(t)
 	testParseEqFilter(t)
 	testParseReplace(t)
+	testParseReplaceWithPath(t)
 	testParseCapturePipeReplace(t)
 
 	testParseBasicFailures(t)
@@ -222,7 +223,7 @@ func testParseReplaceFailure(t *testing.T) {
 			),
 		),
 
-		expectError(`invalid replace: right hand argument is not a string
+		expectError(`invalid replace: right hand argument is not a string or identity
 | routes.running.destination:=:=
 | ............................^`,
 			fromTokens(
@@ -369,6 +370,57 @@ replace:
 				identity("next-hop-interface"),
 				replace(),
 				str("br1"),
+				eof(),
+			),
+		),
+	}
+	runTest(t, tests)
+}
+
+func testParseReplaceWithPath(t *testing.T) {
+	var tests = []test{
+		expectAST(t, `
+pos: 33
+replace:
+- pos: 0
+  identity: currentState
+- pos: 0 
+  path: 
+  - pos: 0 
+    identity: routes
+  - pos: 7
+    identity: running
+  - pos: 15
+    identity: next-hop-interface
+- pos: 35
+  path:
+  - pos: 35
+    identity: capture
+  - pos: 43
+    identity: primary-nic
+  - pos: 55
+    identity: interfaces
+  - pos: 66
+    number: 0
+  - pos: 68
+    identity: name
+`,
+			fromTokens(
+				identity("routes"),
+				dot(),
+				identity("running"),
+				dot(),
+				identity("next-hop-interface"),
+				replace(),
+				identity("capture"),
+				dot(),
+				identity("primary-nic"),
+				dot(),
+				identity("interfaces"),
+				dot(),
+				number(0),
+				dot(),
+				identity("name"),
 				eof(),
 			),
 		),


### PR DESCRIPTION
One of the feature is replacing with the captured state from a capture
entry path. This change add support for it at the parser and create a
unit test for the resolver since resolver has the feature already.