### PR TITLE
Make the AST node a stringer

### DIFF
--- a/nmpolicy/internal/ast/equal.go
+++ b/nmpolicy/internal/ast/equal.go
@@ -28,5 +28,5 @@ func deepEqualStringPtr(lhs, rhs *string) bool {
 
 func (lhs Terminal) DeepEqual(rhs Terminal) bool {
 	return deepEqualStringPtr(rhs.Identity, lhs.Identity) &&
-		deepEqualStringPtr(rhs.String, lhs.String)
+		deepEqualStringPtr(rhs.Str, lhs.Str)
 }

--- a/nmpolicy/internal/ast/equal.go
+++ b/nmpolicy/internal/ast/equal.go
@@ -26,7 +26,7 @@ func deepEqualStringPtr(lhs, rhs *string) bool {
 	return false
 }
 
-func (lhs Terminal) DeepEqual(rhs Terminal) bool {
-	return deepEqualStringPtr(rhs.Identity, lhs.Identity) &&
-		deepEqualStringPtr(rhs.Str, lhs.Str)
+func (t Terminal) DeepEqual(rhs Terminal) bool {
+	return deepEqualStringPtr(rhs.Identity, t.Identity) &&
+		deepEqualStringPtr(rhs.Str, t.Str)
 }

--- a/nmpolicy/internal/ast/equal_test.go
+++ b/nmpolicy/internal/ast/equal_test.go
@@ -38,35 +38,35 @@ func TestTeminalDeepEqual(t *testing.T) {
 		expected bool
 	}{
 		{ast.Terminal{Identity: &literalA}, ast.Terminal{Identity: &literalA}, true},
-		{ast.Terminal{String: &literalA}, ast.Terminal{String: &literalA}, true},
+		{ast.Terminal{Str: &literalA}, ast.Terminal{Str: &literalA}, true},
 		{
-			ast.Terminal{String: &literalA, Identity: &literalB},
-			ast.Terminal{String: &literalA, Identity: &literalB},
+			ast.Terminal{Str: &literalA, Identity: &literalB},
+			ast.Terminal{Str: &literalA, Identity: &literalB},
 			true,
 		},
 		{
-			ast.Terminal{String: nil},
-			ast.Terminal{String: nil},
+			ast.Terminal{Str: nil},
+			ast.Terminal{Str: nil},
 			true,
 		},
 		{
-			ast.Terminal{String: nil},
-			ast.Terminal{String: &literalA},
+			ast.Terminal{Str: nil},
+			ast.Terminal{Str: &literalA},
 			false,
 		},
 		{
-			ast.Terminal{String: &literalA},
-			ast.Terminal{String: &literalB},
+			ast.Terminal{Str: &literalA},
+			ast.Terminal{Str: &literalB},
 			false,
 		},
 		{
-			ast.Terminal{String: &literalA},
-			ast.Terminal{String: newPtr(literalA)},
+			ast.Terminal{Str: &literalA},
+			ast.Terminal{Str: newPtr(literalA)},
 			true,
 		},
 		{
-			ast.Terminal{String: &literalA},
-			ast.Terminal{String: newPtr(literalB)},
+			ast.Terminal{Str: &literalA},
+			ast.Terminal{Str: newPtr(literalB)},
 			false,
 		},
 		{
@@ -90,8 +90,8 @@ func TestTeminalDeepEqual(t *testing.T) {
 			false,
 		},
 		{
-			ast.Terminal{Identity: &literalA, String: &literalA},
-			ast.Terminal{Identity: &literalB, String: newPtr(literalA)},
+			ast.Terminal{Identity: &literalA, Str: &literalA},
+			ast.Terminal{Identity: &literalB, Str: newPtr(literalA)},
 			false,
 		},
 	}

--- a/nmpolicy/internal/ast/types.go
+++ b/nmpolicy/internal/ast/types.go
@@ -16,6 +16,8 @@
 
 package ast
 
+import "fmt"
+
 type Meta struct {
 	Position int `json:"pos"`
 }
@@ -34,4 +36,30 @@ type Node struct {
 	Replace  *TernaryOperator  `json:"replace,omitempty"`
 	Path     *VariadicOperator `json:"path,omitempty"`
 	Terminal
+}
+
+func (n Node) String() string {
+	if n.EqFilter != nil {
+		return fmt.Sprintf("EqFilter(%s)", *n.EqFilter)
+	}
+	if n.Replace != nil {
+		return fmt.Sprintf("Replace(%s)", *n.Replace)
+	}
+	if n.Path != nil {
+		return fmt.Sprintf("Path=%s", *n.Path)
+	}
+	return n.Terminal.String()
+}
+
+func (t Terminal) String() string {
+	if t.Str != nil {
+		return fmt.Sprintf("String=%s", *t.Str)
+	}
+	if t.Identity != nil {
+		return fmt.Sprintf("Identity=%s", *t.Identity)
+	}
+	if t.Number != nil {
+		return fmt.Sprintf("Number=%d", *t.Number)
+	}
+	return ""
 }

--- a/nmpolicy/internal/ast/types.go
+++ b/nmpolicy/internal/ast/types.go
@@ -23,7 +23,7 @@ type Meta struct {
 type TernaryOperator [3]Node
 type VariadicOperator []Node
 type Terminal struct {
-	String   *string `json:"string,omitempty"`
+	Str      *string `json:"string,omitempty"`
 	Identity *string `json:"identity,omitempty"`
 	Number   *int    `json:"number,omitempty"`
 }

--- a/nmpolicy/internal/ast/types_test.go
+++ b/nmpolicy/internal/ast/types_test.go
@@ -68,3 +68,54 @@ eqfilter:
 	}
 	assert.Equal(t, expectedAST, obtainedAST)
 }
+
+func TestFilterString(t *testing.T) {
+	astYAML := `
+pos: 1
+eqfilter:
+- pos: 2
+  path:
+  - pos: 3
+    identity: currentState
+- pos: 4
+  path:
+  - pos: 5
+    identity: routes
+  - pos: 6
+    identity: running
+  - pos: 7
+    identity: table-id
+- pos: 8
+  number: 254
+`
+
+	node := &ast.Node{}
+	assert.NoError(t, yaml.Unmarshal([]byte(astYAML), node))
+
+	assert.Equal(t, "EqFilter([Path=[Identity=currentState] Path=[Identity=routes Identity=running Identity=table-id] Number=254])",
+		node.String())
+}
+
+func TestReplaceString(t *testing.T) {
+	astYAML := `
+pos: 1
+replace:
+- pos: 2
+  identity: currentState
+- pos: 3
+  path:
+  - pos: 4
+    identity: routes
+  - pos: 5
+    identity: running
+  - pos: 6
+    identity: next-hop-interface
+- pos: 7
+  string: br1`
+
+	node := &ast.Node{}
+	assert.NoError(t, yaml.Unmarshal([]byte(astYAML), node))
+
+	assert.Equal(t, "Replace([Identity=currentState Path=[Identity=routes Identity=running Identity=next-hop-interface] String=br1])",
+		node.String())
+}

--- a/nmpolicy/internal/ast/types_test.go
+++ b/nmpolicy/internal/ast/types_test.go
@@ -63,7 +63,7 @@ eqfilter:
 				{Meta: ast.Meta{Position: 6}, Terminal: ast.Terminal{Identity: strPtr("running")}},
 				{Meta: ast.Meta{Position: 7}, Terminal: ast.Terminal{Identity: strPtr("destination")}},
 			}},
-			{Meta: ast.Meta{Position: 8}, Terminal: ast.Terminal{String: strPtr("0.0.0.0/0")}},
+			{Meta: ast.Meta{Position: 8}, Terminal: ast.Terminal{Str: strPtr("0.0.0.0/0")}},
 		},
 	}
 	assert.Equal(t, expectedAST, obtainedAST)

--- a/nmpolicy/internal/capture/stubs_test.go
+++ b/nmpolicy/internal/capture/stubs_test.go
@@ -49,7 +49,7 @@ func (p parserStub) Parse(expression string, tokens []lexer.Token) (ast.Node, er
 		return ast.Node{}, fmt.Errorf("parse failed")
 	}
 	literal := fmt.Sprintf(`{"parser": %s}`, tokens[0].Literal)
-	return ast.Node{Terminal: ast.Terminal{String: &literal}}, nil
+	return ast.Node{Terminal: ast.Terminal{Str: &literal}}, nil
 }
 
 type resolverStub struct {
@@ -64,7 +64,7 @@ func (r resolverStub) Resolve(captureExpressions types.CaptureExpressions, captu
 	capsState := types.CapturedStates{}
 	for id, entry := range captureASTPool {
 		state := types.NMState{}
-		marshaled := fmt.Sprintf(`{"resolver": %s}`, *entry.String)
+		marshaled := fmt.Sprintf(`{"resolver": %s}`, *entry.Str)
 		if err := yaml.Unmarshal([]byte(marshaled), &state); err != nil {
 			return nil, fmt.Errorf("resolve stub failed: unmarshaling `%s`: %v", marshaled, err)
 		}
@@ -81,7 +81,7 @@ func (r resolverStub) ResolveCaptureEntryPath(expression string, captureEntryPat
 	if r.failResolve {
 		return nil, fmt.Errorf("resolve capture entry path failed")
 	}
-	return fmt.Sprintf(`{"resolver": %s}`, *captureEntryPathAST.String), nil
+	return fmt.Sprintf(`{"resolver": %s}`, *captureEntryPathAST.Str), nil
 }
 
 func defaultStubCapturedState(t *testing.T, expression string) types.CapturedState {

--- a/nmpolicy/internal/parser/parser.go
+++ b/nmpolicy/internal/parser/parser.go
@@ -141,7 +141,7 @@ func (p *parser) parseIdentity() error {
 func (p *parser) parseString() error {
 	p.lastNode = &ast.Node{
 		Meta:     ast.Meta{Position: p.currentToken().Position},
-		Terminal: ast.Terminal{String: &p.currentToken().Literal},
+		Terminal: ast.Terminal{Str: &p.currentToken().Literal},
 	}
 	return nil
 }

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -111,7 +111,7 @@ func (r resolver) resolveCaptureASTEntry() (types.NMState, error) {
 	} else if r.currentNode.Replace != nil {
 		return r.resolveReplace()
 	}
-	return nil, fmt.Errorf("root node has unsupported operation : %+v", *r.currentNode)
+	return nil, fmt.Errorf("root node has unsupported operation : %s", *r.currentNode)
 }
 
 func (r resolver) resolveEqFilter() (types.NMState, error) {
@@ -166,7 +166,7 @@ func (r resolver) resolveInputSource() (types.NMState, error) {
 			return nil, err
 		}
 		if resolvedPath.captureEntryName == "" {
-			return nil, fmt.Errorf("invalid path input source, only capture reference is supported")
+			return nil, fmt.Errorf("invalid path input source (%s), only capture reference is supported", r.currentNode)
 		}
 		capturedState, err := r.resolveCaptureEntryName(resolvedPath.captureEntryName)
 		if err != nil {
@@ -175,7 +175,7 @@ func (r resolver) resolveInputSource() (types.NMState, error) {
 		return capturedState, nil
 	}
 
-	return nil, fmt.Errorf("invalid input source %v, only current state or capture reference is supported", *r.currentNode)
+	return nil, fmt.Errorf("invalid input source (%s), only current state or capture reference is supported", *r.currentNode)
 }
 
 func (r resolver) resolveStringOrCaptureEntryPath() (interface{}, error) {

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -179,8 +179,8 @@ func (r resolver) resolveInputSource() (types.NMState, error) {
 }
 
 func (r resolver) resolveStringOrCaptureEntryPath() (interface{}, error) {
-	if r.currentNode.String != nil {
-		return *r.currentNode.String, nil
+	if r.currentNode.Str != nil {
+		return *r.currentNode.Str, nil
 	} else if r.currentNode.Path != nil {
 		return r.resolveCaptureEntryPath()
 	} else {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -510,7 +510,7 @@ func testFailureResolver(t *testing.T) {
 		_, err := nmpolicy.GenerateState(policySpec, stateData, types.CachedState{})
 		assert.EqualError(t, err,
 			"failed to generate state, err: failed to resolve capture expression, "+
-				"err: resolve error: eqfilter error: invalid path input source, only capture reference is supported"+`
+				"err: resolve error: eqfilter error: invalid path input source (Path=[Identity=interfaces]), only capture reference is supported"+`
 | interfaces | routes.running.destination=="0.0.0.0/0"
 | .......................................^`)
 	})


### PR DESCRIPTION
As part of the effort to improve the error messages, AST node is now a stringer.