### PR TITLE
Resolver: Place snippet marker more accuratly

### DIFF
--- a/nmpolicy/internal/resolver/errors.go
+++ b/nmpolicy/internal/resolver/errors.go
@@ -16,18 +16,39 @@
 
 package resolver
 
-import "fmt"
+import (
+	"fmt"
 
-func pathError(format string, a ...interface{}) error {
-	return fmt.Errorf("invalid path: %v", fmt.Errorf(format, a...))
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+type PathError struct {
+	inner     error
+	errorNode *ast.Node
+}
+
+func (r PathError) Unwrap() error {
+	return r.inner
+}
+
+func (r PathError) Error() string {
+	return r.inner.Error()
+}
+
+func pathError(currentStepNode *ast.Node, format string, a ...interface{}) PathError {
+	return wrapWithPathError(currentStepNode, fmt.Errorf(format, a...))
+}
+
+func wrapWithPathError(currentStepNode *ast.Node, err error) PathError {
+	return PathError{inner: fmt.Errorf("invalid path: %v", err), errorNode: currentStepNode}
 }
 
 func wrapWithResolveError(err error) error {
-	return fmt.Errorf("resolve error: %v", err)
+	return fmt.Errorf("resolve error: %w", err)
 }
 
 func wrapWithEqFilterError(err error) error {
-	return fmt.Errorf("eqfilter error: %v", err)
+	return fmt.Errorf("eqfilter error: %w", err)
 }
 
 func replaceError(format string, a ...interface{}) error {
@@ -35,5 +56,5 @@ func replaceError(format string, a ...interface{}) error {
 }
 
 func wrapWithReplaceError(err error) error {
-	return fmt.Errorf("replace error: %v", err)
+	return fmt.Errorf("replace error: %w", err)
 }

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -34,7 +34,7 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 	filtered, err := pathVisitorWithEqFilter.visitMap(inputState)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed applying operation on the path: %v", err)
+		return nil, fmt.Errorf("failed applying operation on the path: %w", err)
 	}
 
 	if filtered == nil {

--- a/nmpolicy/internal/resolver/path.go
+++ b/nmpolicy/internal/resolver/path.go
@@ -98,8 +98,7 @@ func (v pathVisitor) visitMap(originalMap map[string]interface{}) (interface{}, 
 
 	valueToCheck, ok := originalMap[key]
 	if !ok {
-		// TODO: we shouldn't return error on non-existing key
-		return nil, pathError(v.currentStep, "cannot find key %s in %v", key, originalMap)
+		return nil, nil
 	}
 
 	adjustedValue, err := v.visitInterface(valueToCheck)

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -31,7 +31,7 @@ func replace(inputState map[string]interface{}, path ast.VariadicOperator, repla
 	replaced, err := pathVisitorWithReplace.visitMap(inputState)
 
 	if err != nil {
-		return nil, replaceError("failed applying operation on the path: %v", err)
+		return nil, replaceError("failed applying operation on the path: %w", err)
 	}
 
 	replacedMap, ok := replaced.(map[string]interface{})

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -17,6 +17,7 @@
 package resolver
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
@@ -234,8 +235,15 @@ func (r resolver) wrapErrorWithCurrentExpression(err error) error {
 	if err == nil {
 		return nil
 	}
-	if r.currentNode == nil || r.currentExpression == nil {
+
+	var pathError PathError
+	errorNode := r.currentNode
+	if errors.As(err, &pathError) {
+		errorNode = pathError.errorNode
+	}
+
+	if errorNode == nil || r.currentExpression == nil {
 		return err
 	}
-	return expression.WrapError(err, *r.currentExpression, r.currentNode.Meta.Position)
+	return expression.WrapError(err, *r.currentExpression, errorNode.Meta.Position)
 }

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -135,6 +135,7 @@ func TestFilter(t *testing.T) {
 		testFilterDifferentTypeOnPath(t)
 		testFilterOptionalField(t)
 		testFilterNonCaptureRefPathAtThirdArg(t)
+		testFilterWithInvalidInputSource(t)
 
 		testReplaceCurrentState(t)
 		testReplaceCapturedState(t)
@@ -463,7 +464,7 @@ base-iface-routes: routes.running.next-hop-interface==capture
 `)
 		testToRun.err = `resolve error: eqfilter error: path capture ref is missing capture entry name
 | routes.running.next-hop-interface==capture
-| .................................^`
+| ...................................^`
 
 		runTest(t, &testToRun)
 	})
@@ -476,7 +477,7 @@ base-iface-routes: routes.running.next-hop-interface==capture.default-gw.routes
 `)
 		testToRun.err = `resolve error: eqfilter error: capture entry 'default-gw' not found
 | routes.running.next-hop-interface==capture.default-gw.routes
-| .................................^`
+| ...................................^`
 
 		runTest(t, &testToRun)
 	})
@@ -502,7 +503,7 @@ default-gw:
 			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]' " +
 			"with path '[routes running badfield]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.running.badfield.next-hop-interface
-| .................................^`
+| ...................................^`
 
 		runTest(t, &testToRun)
 	})
@@ -527,7 +528,7 @@ default-gw:
 			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]' " +
 			"with path '[routes 1]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.1.0.next-hop-interface
-| .................................^`
+| ...................................^`
 
 		runTest(t, &testToRun)
 	})
@@ -551,7 +552,7 @@ default-gw:
 		testToRun.err = "resolve error: eqfilter error: step 'badfield' from path '[routes badfield]' not found at map state " +
 			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.badfield
-| .................................^`
+| ...................................^`
 
 		runTest(t, &testToRun)
 	})
@@ -575,7 +576,7 @@ default-gw:
 		testToRun.err = "resolve error: eqfilter error: step '6' from path '[routes running 6]' not found at slice state " +
 			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.running.6
-| .................................^`
+| ...................................^`
 
 		runTest(t, &testToRun)
 	})
@@ -589,7 +590,21 @@ base-iface-routes: routes.running.next-hop-interface==routes.running
 
 		testToRun.err = `resolve error: eqfilter error: not supported filtered value path. Only paths with a capture entry reference are supported
 | routes.running.next-hop-interface==routes.running
-| .................................^`
+| ...................................^`
+		runTest(t, &testToRun)
+	})
+}
+
+func testFilterWithInvalidInputSource(t *testing.T) {
+	t.Run("Filter list with invalid input source", func(t *testing.T) {
+		testToRun := withCaptureExpressions(t, `
+base-iface-routes: invalidInputSource | routes.running.next-hop-interface=='eth1'
+`)
+
+		testToRun.err =
+			`resolve error: eqfilter error: invalid path input source (Path=[Identity=invalidInputSource]), only capture reference is supported
+| invalidInputSource | routes.running.next-hop-interface=='eth1'
+| ^`
 		runTest(t, &testToRun)
 	})
 }

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -636,28 +636,13 @@ base-iface-routes: routes.running.next-hop-interface=='eth1'
 func testFilterBadPath(t *testing.T) {
 	t.Run("Filter list with non existing path", func(t *testing.T) {
 		testToRun := withCaptureExpressions(t, `
-base-iface-routes: routes.badfield.next-hop-interface==capture.default-gw.routes.running.0.next-hop-interface
+base-iface-routes: routes.badfield.next-hop-interface=="eth1"
 `)
-		testToRun.capturedStatesCache = `
-default-gw:
-  state: 
-    routes:
-      running:
-      - destination: 0.0.0.0/0
-        next-hop-address: 1.2.3.4
-        next-hop-interface: eth1
-        table-id: 254
-`
-		testToRun.err =
-			`resolve error: eqfilter error: failed applying operation on the path: invalid path: cannot find key badfield in ` +
-				`map[config:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254] ` +
-				`map[destination:1.1.1.0/24 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]] ` +
-				`running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254] ` +
-				`map[destination:1.1.1.0/24 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254] ` +
-				`map[destination:2.2.2.0/24 next-hop-address:192.168.200.1 next-hop-interface:eth2 table-id:254]]]
-| routes.badfield.next-hop-interface==capture.default-gw.routes.running.0.next-hop-interface
-| .......^`
+		testToRun.expectedCapturedStates = `
 
+base-iface-routes:
+  state:
+`
 		runTest(t, &testToRun)
 	})
 }

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -512,7 +512,7 @@ func testFailureResolver(t *testing.T) {
 			"failed to generate state, err: failed to resolve capture expression, "+
 				"err: resolve error: eqfilter error: invalid path input source (Path=[Identity=interfaces]), only capture reference is supported"+`
 | interfaces | routes.running.destination=="0.0.0.0/0"
-| .......................................^`)
+| ^`)
 	})
 }
 


### PR DESCRIPTION
The PR contains 3 commits-

1. Place snippet marker on correct part of a Ternary operation
2. Place snippet marker on correct key of a path
3. Support optional keys on any part of the path (continues PR #75, which allowed optional keys on the last key of the path).