### PR TITLE
docs: Add .nojekyll build marker

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,6 +24,7 @@ build:
 	fi
 	rm -rf $(dest_dir)
 	bundle exec jekyll build --trace --source . --destination $(dest_dir)
+	touch $(dest_dir)/.nojekyll
 
 .PHONY: check
 check: build


### PR DESCRIPTION
To prevent github from running jekyll on the already generated page a
.jekyll have has to be added.

https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#troubleshooting-publishing-problems-with-your-github-pages-site

Signed-off-by: Quique Llorente <ellorent@redhat.com>