### PR TITLE
types: Move main MetaInfo to Cache

### DIFF
--- a/nmpolicy/internal/operations.go
+++ b/nmpolicy/internal/operations.go
@@ -58,12 +58,14 @@ func GenerateState(policySpec types.PolicySpec, currentState types.NMState, cach
 	timestamp := time.Now().UTC()
 	timestampCapturesState(capturedStates, timestamp)
 	return types.GeneratedState{
-		Cache:        types.CachedState{CapturedStates: capturedStates},
-		DesiredState: desiredState,
-		MetaInfo: nmpolicytypes.MetaInfo{
-			Version:   "0",
-			TimeStamp: timestamp,
+		Cache: types.CachedState{
+			MetaInfo: nmpolicytypes.MetaInfo{
+				Version:   "0",
+				TimeStamp: timestamp,
+			},
+			CapturedStates: capturedStates,
 		},
+		DesiredState: desiredState,
 	}, nil
 }
 

--- a/nmpolicy/internal/types/types.go
+++ b/nmpolicy/internal/types/types.go
@@ -33,12 +33,12 @@ type PolicySpec struct {
 
 type CachedState struct {
 	CapturedStates CapturedStates
+	MetaInfo       nmpolicytypes.MetaInfo
 }
 
 type GeneratedState struct {
 	Cache        CachedState
 	DesiredState NMState
-	MetaInfo     nmpolicytypes.MetaInfo
 }
 
 type CapturedState struct {

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -57,7 +57,6 @@ func GenerateState(policySpec types.PolicySpec,
 	if err != nil {
 		return generatedState, err
 	}
-
 	generatedState, err = toGeneratedState(internalGeneratedState)
 	if err != nil {
 		return generatedState, err
@@ -132,12 +131,13 @@ func toInternalCachedState(cachedState types.CachedState) (internaltypes.CachedS
 }
 
 func toCachedState(internalCachedState internaltypes.CachedState) (types.CachedState, error) {
-	if len(internalCachedState.CapturedStates) == 0 {
-		return types.CachedState{}, nil
-	}
 	cachedState := types.CachedState{
-		Capture: map[string]types.CaptureState{},
+		MetaInfo: internalCachedState.MetaInfo,
 	}
+	if len(internalCachedState.CapturedStates) == 0 {
+		return cachedState, nil
+	}
+	cachedState.Capture = map[string]types.CaptureState{}
 	for captureEntryName, internalCapturedState := range internalCachedState.CapturedStates {
 		capturedState, err := toCapturedState(internalCapturedState)
 		if err != nil {
@@ -158,7 +158,6 @@ func toGeneratedState(internalGeneratedState internaltypes.GeneratedState) (type
 		return types.GeneratedState{}, err
 	}
 	return types.GeneratedState{
-		MetaInfo:     internalGeneratedState.MetaInfo,
 		DesiredState: desiredState,
 		Cache:        cachedState,
 	}, nil

--- a/nmpolicy/types/types.go
+++ b/nmpolicy/types/types.go
@@ -26,13 +26,13 @@ type PolicySpec struct {
 }
 
 type CachedState struct {
-	Capture map[string]CaptureState
+	MetaInfo MetaInfo
+	Capture  map[string]CaptureState
 }
 
 type GeneratedState struct {
 	Cache        CachedState
 	DesiredState NMState
-	MetaInfo     MetaInfo
 }
 
 type CaptureState struct {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -49,8 +49,8 @@ func testEmptyPolicy(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		expectedEmptyState := types.GeneratedState{MetaInfo: types.MetaInfo{Version: "0"}}
-		assert.NotEqual(t, time.Time{}, s.MetaInfo.TimeStamp)
+		expectedEmptyState := types.GeneratedState{Cache: types.CachedState{MetaInfo: types.MetaInfo{Version: "0"}}}
+		assert.NotEqual(t, time.Time{}, s.Cache.MetaInfo.TimeStamp)
 		assert.Equal(t, expectedEmptyState, resetTimeStamp(s))
 	})
 }
@@ -70,7 +70,9 @@ func testPolicyWithOnlyDesiredState(t *testing.T) {
 		assert.NoError(t, err)
 		expectedState := types.GeneratedState{
 			DesiredState: stateData,
-			MetaInfo:     types.MetaInfo{Version: "0"},
+			Cache: types.CachedState{
+				MetaInfo: types.MetaInfo{Version: "0"},
+			},
 		}
 		assert.Equal(t, expectedState, resetTimeStamp(s))
 	})
@@ -90,7 +92,8 @@ func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 		}
 
 		cacheState := types.CachedState{
-			Capture: map[string]types.CaptureState{capID0: {State: []byte("name: some captured state")}},
+			MetaInfo: types.MetaInfo{Version: "0"},
+			Capture:  map[string]types.CaptureState{capID0: {State: []byte("name: some captured state")}},
 		}
 		cacheState.Capture, err = formatCapturedStates(cacheState.Capture)
 		assert.NoError(t, err)
@@ -104,7 +107,6 @@ func testPolicyWithCachedCaptureAndDesiredStateWithoutRef(t *testing.T) {
 		expectedState := types.GeneratedState{
 			Cache:        cacheState,
 			DesiredState: stateData,
-			MetaInfo:     types.MetaInfo{Version: "0"},
 		}
 		assert.Equal(t, expectedState, resetTimeStamp(s))
 	})
@@ -282,11 +284,12 @@ func testPolicyWithoutCache(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected := types.GeneratedState{
-			MetaInfo: types.MetaInfo{
-				Version: "0",
-			},
+
 			DesiredState: mainExpectedDesiredState,
 			Cache: types.CachedState{
+				MetaInfo: types.MetaInfo{
+					Version: "0",
+				},
 				Capture: map[string]types.CaptureState{
 					"default-gw":        defaultGwCapturedState,
 					"base-iface":        baseIfaceCapturedState,
@@ -328,11 +331,11 @@ func testPolicyWithFullCache(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected := types.GeneratedState{
-			MetaInfo: types.MetaInfo{
-				Version: "0",
-			},
 			DesiredState: mainExpectedDesiredState,
 			Cache: types.CachedState{
+				MetaInfo: types.MetaInfo{
+					Version: "0",
+				},
 				Capture: map[string]types.CaptureState{
 					"base-iface":    baseIfaceCapturedState,
 					"bridge-routes": bridgeRoutesCapturedState,
@@ -374,11 +377,11 @@ func testPolicyWithPartialCache(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected := types.GeneratedState{
-			MetaInfo: types.MetaInfo{
-				Version: "0",
-			},
 			DesiredState: mainExpectedDesiredState,
 			Cache: types.CachedState{
+				MetaInfo: types.MetaInfo{
+					Version: "0",
+				},
 				Capture: map[string]types.CaptureState{
 					"default-gw":        defaultGwCapturedState,
 					"base-iface":        baseIfaceCapturedState,
@@ -436,9 +439,9 @@ func testGenerateUniqueTimestamps(t *testing.T) {
 			stateData,
 			cacheState)
 		assert.NoError(t, err)
-		assert.Equal(t, obtained.MetaInfo.TimeStamp, obtained.Cache.Capture[capID0].MetaInfo.TimeStamp)
+		assert.Equal(t, obtained.Cache.MetaInfo.TimeStamp, obtained.Cache.Capture[capID0].MetaInfo.TimeStamp)
 		assert.Equal(t, cacheState.Capture[capID1].MetaInfo, obtained.Cache.Capture[capID1].MetaInfo)
-		assert.Greater(t, obtained.MetaInfo.TimeStamp.Sub(beforeGenerate), time.Duration(0))
+		assert.Greater(t, obtained.Cache.MetaInfo.TimeStamp.Sub(beforeGenerate), time.Duration(0))
 		assert.Greater(t, obtained.Cache.Capture[capID0].MetaInfo.TimeStamp.Sub(beforeGenerate), time.Duration(0))
 	})
 }
@@ -517,7 +520,7 @@ func testFailureResolver(t *testing.T) {
 }
 
 func resetTimeStamp(generatedState types.GeneratedState) types.GeneratedState {
-	generatedState.MetaInfo.TimeStamp = time.Time{}
+	generatedState.Cache.MetaInfo.TimeStamp = time.Time{}
 	generatedState.Cache.Capture = resetCapturedStatesTimeStamp(generatedState.Cache.Capture)
 	return generatedState
 }


### PR DESCRIPTION
At the cli PR is needed to dump the main MetaInfo but this cannot be
dumped at desiredState since that would break `nmstate apply`. This
change move the main MetaInfo to `Cache` field so the whole `Cache`
field can be dumped at the cli.