### PR TITLE
types: Remove main MetaInfo

### DIFF
--- a/docs/examples/all-linux-bridges-down/captured.yaml
+++ b/docs/examples/all-linux-bridges-down/captured.yaml
@@ -1,6 +1,7 @@
 linux-bridges:
   metaInfo:
     time: "2021-12-15T13:45:40Z"
+    version: "0"
   state:
     interfaces:
     - name: br1
@@ -15,6 +16,7 @@ linux-bridges:
 linux-bridges-down:
   metaInfo:
     time: "2021-12-15T13:45:40Z"
+    version: "0"
   state:
     interfaces:
     - name: br1

--- a/docs/examples/bridge-on-default-gw-dhcp/captured.yaml
+++ b/docs/examples/bridge-on-default-gw-dhcp/captured.yaml
@@ -1,6 +1,7 @@
 base-iface:
   metaInfo:
     time: "2021-12-15T13:45:40Z"
+    version: "0"
   state:
     interfaces:
     - name: eth1
@@ -18,6 +19,7 @@ base-iface:
 default-gw:
   metaInfo:
      time: "2021-12-15T13:45:40Z"
+     version: "0"
   state:
     routes:
       running:

--- a/docs/examples/bridge-on-default-gw-no-dhcp/captured.yaml
+++ b/docs/examples/bridge-on-default-gw-no-dhcp/captured.yaml
@@ -1,6 +1,7 @@
 base-iface:
   metaInfo:
     time: "2021-12-15T13:45:40Z"
+    version: "0"
   state:
     interfaces:
     - name: eth1
@@ -18,6 +19,7 @@ base-iface:
 default-gw:
   metaInfo:
      time: "2021-12-15T13:45:40Z"
+     version: "0"
   state:
     routes:
       running:
@@ -28,6 +30,7 @@ default-gw:
 base-iface-routes:
   metaInfo:
      time: "2021-12-15T13:45:40Z"
+     version: "0"
   state:
     routes:
       running:
@@ -42,6 +45,7 @@ base-iface-routes:
 bridge-routes:
   metaInfo:
      time: "2021-12-15T13:45:40Z"
+     version: "0"
   state:
     routes:
       running:

--- a/docs/examples/ovs-slb-bond-primary-secondary/captured.yaml
+++ b/docs/examples/ovs-slb-bond-primary-secondary/captured.yaml
@@ -1,6 +1,7 @@
 primary-nic:
   metaInfo:
     time: "2021-12-15T13:45:40Z"
+    version: "0"
   state:
     interfaces:
     - name: eth1
@@ -14,6 +15,7 @@ primary-nic:
 secondary-nic:
   metaInfo:
     time: "2021-12-15T13:45:40Z"
+    version: "0"
   state:
     interfaces:
     - name: eth2

--- a/nmpolicy/internal/operations.go
+++ b/nmpolicy/internal/operations.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
-	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
 )
 
 func GenerateState(policySpec types.PolicySpec, currentState types.NMState, cachedState types.CachedState) (types.GeneratedState, error) {
@@ -55,22 +54,19 @@ func GenerateState(policySpec types.PolicySpec, currentState types.NMState, cach
 		}
 	}
 
-	timestamp := time.Now().UTC()
-	timestampCapturesState(capturedStates, timestamp)
+	stampCapturedStates(capturedStates)
 	return types.GeneratedState{
 		Cache:        types.CachedState{CapturedStates: capturedStates},
 		DesiredState: desiredState,
-		MetaInfo: nmpolicytypes.MetaInfo{
-			Version:   "0",
-			TimeStamp: timestamp,
-		},
 	}, nil
 }
 
-func timestampCapturesState(capturedStates types.CapturedStates, timeStamp time.Time) {
+func stampCapturedStates(capturedStates types.CapturedStates) {
+	now := time.Now().UTC()
 	for captureID, capturedState := range capturedStates {
 		if capturedState.MetaInfo.TimeStamp.IsZero() {
-			capturedState.MetaInfo.TimeStamp = timeStamp
+			capturedState.MetaInfo.TimeStamp = now
+			capturedState.MetaInfo.Version = "0"
 			capturedStates[captureID] = capturedState
 		}
 	}

--- a/nmpolicy/internal/types/types.go
+++ b/nmpolicy/internal/types/types.go
@@ -38,7 +38,6 @@ type CachedState struct {
 type GeneratedState struct {
 	Cache        CachedState
 	DesiredState NMState
-	MetaInfo     nmpolicytypes.MetaInfo
 }
 
 type CapturedState struct {

--- a/nmpolicy/operations.go
+++ b/nmpolicy/operations.go
@@ -158,7 +158,6 @@ func toGeneratedState(internalGeneratedState internaltypes.GeneratedState) (type
 		return types.GeneratedState{}, err
 	}
 	return types.GeneratedState{
-		MetaInfo:     internalGeneratedState.MetaInfo,
 		DesiredState: desiredState,
 		Cache:        cachedState,
 	}, nil

--- a/nmpolicy/types/types.go
+++ b/nmpolicy/types/types.go
@@ -32,7 +32,6 @@ type CachedState struct {
 type GeneratedState struct {
 	Cache        CachedState
 	DesiredState NMState
-	MetaInfo     MetaInfo
 }
 
 type CaptureState struct {


### PR DESCRIPTION
The MetaInfo version is really needed at captured states. This change
move the version there.