### PR TITLE
resolver: Implement walk with the pathVisitor

### DIFF
--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -31,7 +31,7 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 		shouldFilterMap:   true,
 	}
 
-	filtered, err := pathVisitorWithEqFilter.visitMap(inputState)
+	filtered, err := pathVisitorWithEqFilter.visitInterface(inputState)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed applying operation on the path: %w", err)

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -40,7 +40,7 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 		visitMapWithIdentityFn:   filterMapEntryWithVisitResult,
 	}
 
-	filtered, err := pathVisitorWithEqFilter.visitInterface(inputState)
+	filtered, err := pathVisitorWithEqFilter.visitNextStep(inputState)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed applying operation on the path: %w", err)
@@ -80,14 +80,13 @@ func filterMapEntryWithVisitResult(v pathVisitor, mapToVisit map[string]interfac
 		return nil, nil
 	}
 
-	visitResult, err := v.visitInterface(interfaceToVisit)
+	visitResult, err := v.visitNextStep(interfaceToVisit)
 	if err != nil {
 		return nil, err
 	}
 	if visitResult == nil {
 		return nil, nil
 	}
-
 	filteredMap := map[string]interface{}{}
 	if !shouldFilter(v.currentStep) {
 		for k, v := range mapToVisit {
@@ -102,7 +101,7 @@ func filterSliceEntriesWithVisitResult(v pathVisitor, sliceToVisit []interface{}
 	filteredSlice := []interface{}{}
 	hasVisitResult := false
 	for _, interfaceToVisit := range sliceToVisit {
-		visitResult, err := v.visitInterface(interfaceToVisit)
+		visitResult, err := v.visitNextStep(interfaceToVisit)
 		if err != nil {
 			return nil, err
 		}
@@ -121,7 +120,10 @@ func filterSliceEntriesWithVisitResult(v pathVisitor, sliceToVisit []interface{}
 }
 
 func shouldFilter(currentStep *ast.Node) bool {
-	if currentStep == nil || currentStep.Identity == nil {
+	if currentStep == nil {
+		return true
+	}
+	if currentStep.Identity == nil {
 		return false
 	}
 	_, ok := filterLookupMap[*currentStep.Identity]

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -25,10 +25,14 @@ import (
 
 func filter(inputState map[string]interface{}, path ast.VariadicOperator, expectedValue interface{}) (map[string]interface{}, error) {
 	pathVisitorWithEqFilter := pathVisitor{
-		path:              path,
-		lastMapFn:         mapContainsValue(expectedValue),
-		shouldFilterSlice: true,
-		shouldFilterMap:   true,
+		path:      path,
+		lastMapFn: mapContainsValue(expectedValue),
+		filterLookupMap: map[string]bool{
+			"interfaces": true,
+			"routes":     true,
+			"running":    true,
+			"config":     true,
+		},
 	}
 
 	filtered, err := pathVisitorWithEqFilter.visitInterface(inputState)

--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -25,8 +25,10 @@ import (
 
 func filter(inputState map[string]interface{}, path ast.VariadicOperator, expectedValue interface{}) (map[string]interface{}, error) {
 	pathVisitorWithEqFilter := pathVisitor{
-		path:      path,
-		lastMapFn: mapContainsValue(expectedValue),
+		path:                     path,
+		lastMapFn:                mapContainsValue(expectedValue),
+		visitSliceWithoutIndexFn: pathVisitor.visitSliceWithoutIndex,
+		visitMapWithIdentityFn:   pathVisitor.visitMapWithIdentity,
 		filterLookupMap: map[string]bool{
 			"interfaces": true,
 			"routes":     true,

--- a/nmpolicy/internal/resolver/path.go
+++ b/nmpolicy/internal/resolver/path.go
@@ -57,6 +57,10 @@ func (v pathVisitor) visitInterface(inputState interface{}) (interface{}, error)
 }
 
 func (v pathVisitor) visitSlice(originalSlice []interface{}) (interface{}, error) {
+	return v.visitSliceWithoutIndex(originalSlice)
+}
+
+func (v pathVisitor) visitSliceWithoutIndex(originalSlice []interface{}) (interface{}, error) {
 	adjustedSlice := []interface{}{}
 	sliceEmptyAfterApply := true
 	for _, valueToCheck := range originalSlice {
@@ -83,9 +87,11 @@ func (v pathVisitor) visitMap(originalMap map[string]interface{}) (interface{}, 
 	if v.currentStep.Identity == nil {
 		return nil, pathError(v.currentStep, "%v has unsupported fromat", *v.currentStep)
 	}
-	key := *v.currentStep.Identity
+	return v.visitMapWithIdentity(originalMap, *v.currentStep.Identity)
+}
 
-	valueToCheck, ok := originalMap[key]
+func (v pathVisitor) visitMapWithIdentity(originalMap map[string]interface{}, identity string) (interface{}, error) {
+	valueToCheck, ok := originalMap[identity]
 	if !ok {
 		return nil, nil
 	}
@@ -104,7 +110,7 @@ func (v pathVisitor) visitMap(originalMap map[string]interface{}) (interface{}, 
 			adjustedMap[k] = v
 		}
 	}
-	adjustedMap[key] = adjustedValue
+	adjustedMap[identity] = adjustedValue
 	return adjustedMap, nil
 }
 

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -22,8 +22,10 @@ import (
 
 func replace(inputState map[string]interface{}, path ast.VariadicOperator, replaceValue interface{}) (map[string]interface{}, error) {
 	pathVisitorWithReplace := pathVisitor{
-		path:      path,
-		lastMapFn: replaceMapFieldValue(replaceValue),
+		path:                     path,
+		lastMapFn:                replaceMapFieldValue(replaceValue),
+		visitSliceWithoutIndexFn: pathVisitor.visitSliceWithoutIndex,
+		visitMapWithIdentityFn:   pathVisitor.visitMapWithIdentity,
 	}
 
 	replaced, err := pathVisitorWithReplace.visitInterface(inputState)

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -28,7 +28,7 @@ func replace(inputState map[string]interface{}, path ast.VariadicOperator, repla
 		shouldFilterMap:   false,
 	}
 
-	replaced, err := pathVisitorWithReplace.visitMap(inputState)
+	replaced, err := pathVisitorWithReplace.visitInterface(inputState)
 
 	if err != nil {
 		return nil, replaceError("failed applying operation on the path: %w", err)

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -22,10 +22,8 @@ import (
 
 func replace(inputState map[string]interface{}, path ast.VariadicOperator, replaceValue interface{}) (map[string]interface{}, error) {
 	pathVisitorWithReplace := pathVisitor{
-		path:              path,
-		lastMapFn:         replaceMapFieldValue(replaceValue),
-		shouldFilterSlice: false,
-		shouldFilterMap:   false,
+		path:      path,
+		lastMapFn: replaceMapFieldValue(replaceValue),
 	}
 
 	replaced, err := pathVisitorWithReplace.visitInterface(inputState)

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -28,7 +28,7 @@ func replace(inputState map[string]interface{}, path ast.VariadicOperator, repla
 		visitMapWithIdentityFn:   replaceMapEntryWithVisitResult,
 	}
 
-	replaced, err := pathVisitorWithReplace.visitInterface(inputState)
+	replaced, err := pathVisitorWithReplace.visitNextStep(inputState)
 
 	if err != nil {
 		return nil, replaceError("failed applying operation on the path: %w", err)
@@ -59,7 +59,7 @@ func replaceMapEntryWithVisitResult(v pathVisitor, mapToVisit map[string]interfa
 		return nil, nil
 	}
 
-	visitResult, err := v.visitInterface(interfaceToVisit)
+	visitResult, err := v.visitNextStep(interfaceToVisit)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func replaceMapEntryWithVisitResult(v pathVisitor, mapToVisit map[string]interfa
 func replaceSliceEntriesWithVisitResult(v pathVisitor, sliceToVisit []interface{}) (interface{}, error) {
 	replacedSlice := make([]interface{}, len(sliceToVisit))
 	for i, interfaceToVisit := range sliceToVisit {
-		visitResult, err := v.visitInterface(interfaceToVisit)
+		visitResult, err := v.visitNextStep(interfaceToVisit)
 		if err != nil {
 			return nil, err
 		}

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -142,6 +142,7 @@ func TestFilter(t *testing.T) {
 		testReplaceCurrentState(t)
 		testReplaceCapturedState(t)
 		testReplaceWithCaptureRef(t)
+		testReplaceOptionalField(t)
 	})
 }
 
@@ -872,6 +873,55 @@ default-gw-br1-first-port:
         table-id: 254
 `,
 		}
+		runTest(t, &testToRun)
+	})
+}
+
+func testReplaceOptionalField(t *testing.T) {
+	t.Run("Replace optional field", func(t *testing.T) {
+		testToRun := test{
+			capturedStatesCache: `
+eth2-interface:
+  state:
+    interfaces:
+    - name: eth2
+      type: ethernet
+      state: down
+`,
+			captureASTPool: `
+description-eth2:
+  pos: 1
+  replace:
+  - pos: 2
+    path:
+    - pos: 3
+      identity: capture
+    - pos: 4
+      identity: eth2-interface
+  - pos: 5
+    path:
+    - pos: 6
+      identity: interfaces
+    - pos: 7
+      identity: description
+  - pos: 8
+    string: 2nd ethernet interface
+`,
+			expectedCapturedStates: `
+eth2-interface:
+  state:
+    interfaces:
+    - name: eth2
+      type: ethernet
+      state: down
+description-eth2:
+  state:
+    interfaces:
+    - name: eth2
+      description: "2nd ethernet interface"
+      type: ethernet
+      state: down
+`}
 		runTest(t, &testToRun)
 	})
 }

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -502,9 +502,8 @@ default-gw:
          next-hop-interface: eth1
          table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: failed walking non map state " +
-			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]' " +
-			"with path '[routes running badfield]'" + `
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: unexpected non numeric step for slice state " +
+			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.running.badfield.next-hop-interface
 | .....................................................................^`
 
@@ -527,9 +526,8 @@ default-gw:
          next-hop-interface: eth1
          table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: failed walking non slice state " +
-			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]' " +
-			"with path '[routes 1]'" + `
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: unexpected non identity step for map state " +
+			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.1.0.next-hop-interface
 | .............................................................^`
 		runTest(t, &testToRun)
@@ -551,7 +549,7 @@ default-gw:
         next-hop-interface: eth1
         table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: step 'badfield' from path '[routes badfield]' not found at map state " +
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: step not found at map state " +
 			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.badfield
 | .............................................................^`
@@ -575,7 +573,7 @@ default-gw:
         next-hop-interface: eth1
         table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: step '6' from path '[routes running 6]' not found at slice state " +
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: step not found at slice state " +
 			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.running.6
 | .....................................................................^`

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -412,10 +412,10 @@ func testFilterDifferentTypeOnPath(t *testing.T) {
 invalid-path-type: interfaces.ipv4.address=="10.244.0.1"
 `)
 		testToRun.err = `resolve error: eqfilter error: failed applying operation on the path: ` +
-			`type missmatch: the value in the path doesn't match the value to filter. ` +
+			`invalid path: type missmatch: the value in the path doesn't match the value to filter. ` +
 			`"[]interface {}" != "string" -> [map[ip:10.244.0.1 prefix-length:24] map[ip:169.254.1.0 prefix-length:16]] != 10.244.0.1
 | interfaces.ipv4.address=="10.244.0.1"
-| .......................^`
+| ................^`
 
 		runTest(t, &testToRun)
 	})
@@ -532,7 +532,6 @@ default-gw:
 			"with path '[routes 1]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.1.0.next-hop-interface
 | .............................................................^`
-
 		runTest(t, &testToRun)
 	})
 }
@@ -625,9 +624,9 @@ base-iface-routes: routes.running.next-hop-interface=='eth1'
 
 		testToRun.err =
 			`resolve error: eqfilter error: failed applying operation on the path: ` +
-				`invalid path: invalid type <nil> for identity step 'Identity=running'
+				`invalid path: invalid type <nil> for identity step 'Identity=next-hop-interface'
 | routes.running.next-hop-interface=='eth1'
-| .......^`
+| ...............^`
 
 		runTest(t, &testToRun)
 	})

--- a/nmpolicy/internal/resolver/walk.go
+++ b/nmpolicy/internal/resolver/walk.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func walk(inputState map[string]interface{}, pathSteps ast.VariadicOperator) (interface{}, error) {
+	pathVisitorWithWalkOp := pathVisitor{
+		stateVisitor: &walkOpVisitor{},
+	}
+
+	visitResult, err := pathVisitorWithWalkOp.visitNextStep(path{steps: pathSteps}, inputState)
+	if err != nil {
+		return nil, fmt.Errorf("failed walking path: %w", err)
+	}
+
+	return visitResult, nil
+}
+
+type walkOpVisitor struct{}
+
+func (*walkOpVisitor) visitLastMap(mapToAccess map[string]interface{}, accessKey string) (interface{}, error) {
+	v, ok := mapToAccess[accessKey]
+	if !ok {
+		return nil, fmt.Errorf("step not found at map state '%+v'", mapToAccess)
+	}
+	return v, nil
+}
+
+func (*walkOpVisitor) visitLastSlice(sliceToAccess []interface{}, accessIdx int) (interface{}, error) {
+	if len(sliceToAccess) <= accessIdx {
+		return nil, fmt.Errorf("step not found at slice state '%+v'", sliceToAccess)
+	}
+	return sliceToAccess[accessIdx], nil
+}
+
+func (*walkOpVisitor) visitSliceWithoutIndex(sp stepVisitor, p path, sliceToVisit []interface{}) (interface{}, error) {
+	return nil, pathError(p.peekNextStep(), "unexpected non numeric step for slice state '%+v'", sliceToVisit)
+}
+
+func (w *walkOpVisitor) visitSliceWithIndex(sv stepVisitor, p path, sliceToVisit []interface{}, index int) (interface{}, error) {
+	interfaceToVisit, err := w.visitLastSlice(sliceToVisit, index)
+	if err != nil {
+		return nil, wrapWithPathError(p.currentStep, err)
+	}
+	return sv.visitNextStep(p, interfaceToVisit)
+}
+
+func (w *walkOpVisitor) visitMapWithIdentity(sv stepVisitor, p path,
+	mapToVisit map[string]interface{}, identity string) (interface{}, error) {
+	interfaceToVisit, err := w.visitLastMap(mapToVisit, identity)
+	if err != nil {
+		return nil, wrapWithPathError(p.currentStep, err)
+	}
+	return sv.visitNextStep(p, interfaceToVisit)
+}


### PR DESCRIPTION
The path walk logic can be replaced by the pathVisitor to remove code.

Closes https://github.com/nmstate/nmpolicy/issues/83