### PR TITLE
resolver: Refactor visitor pattern

### DIFF
--- a/nmpolicy/internal/resolver/filter.go
+++ b/nmpolicy/internal/resolver/filter.go
@@ -23,15 +23,8 @@ import (
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
 )
 
-func filter(inputState map[string]interface{}, path ast.VariadicOperator, expectedValue interface{}) (map[string]interface{}, error) {
-	pathVisitorWithEqFilter := pathVisitor{
-		path:              path,
-		lastMapFn:         mapContainsValue(expectedValue),
-		shouldFilterSlice: true,
-		shouldFilterMap:   true,
-	}
-
-	filtered, err := pathVisitorWithEqFilter.visitMap(inputState)
+func filter(inputState map[string]interface{}, pathSteps ast.VariadicOperator, expectedValue interface{}) (map[string]interface{}, error) {
+	filtered, err := visitState(newPath(pathSteps), inputState, &eqFilterVisitor{expectedValue: expectedValue})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed applying operation on the path: %w", err)
@@ -48,19 +41,82 @@ func filter(inputState map[string]interface{}, path ast.VariadicOperator, expect
 	return filteredMap, nil
 }
 
-func mapContainsValue(expectedValue interface{}) mapEntryVisitFn {
-	return func(mapToFilter map[string]interface{}, filterKey string) (interface{}, error) {
-		obtainedValue, ok := mapToFilter[filterKey]
-		if !ok {
-			return nil, nil
-		}
-		if reflect.TypeOf(obtainedValue) != reflect.TypeOf(expectedValue) {
-			return nil, fmt.Errorf(`type missmatch: the value in the path doesn't match the value to filter. `+
-				`"%T" != "%T" -> %+v != %+v`, obtainedValue, expectedValue, obtainedValue, expectedValue)
-		}
-		if obtainedValue == expectedValue {
-			return mapToFilter, nil
-		}
+type eqFilterVisitor struct {
+	mergeVisitResult bool
+	expectedValue    interface{}
+}
+
+func (e eqFilterVisitor) visitLastMap(p path, mapToFilter map[string]interface{}) (interface{}, error) {
+	obtainedValue, ok := mapToFilter[*p.currentStep.Identity]
+	if !ok {
 		return nil, nil
 	}
+	if reflect.TypeOf(obtainedValue) != reflect.TypeOf(e.expectedValue) {
+		return nil, pathError(p.currentStep, `type missmatch: the value in the path doesn't match the value to filter. `+
+			`"%T" != "%T" -> %+v != %+v`, obtainedValue, e.expectedValue, obtainedValue, e.expectedValue)
+	}
+	if obtainedValue == e.expectedValue {
+		return mapToFilter, nil
+	}
+	return nil, nil
+}
+
+func (e eqFilterVisitor) visitLastSlice(p path, sliceToVisit []interface{}) (interface{}, error) {
+	if p.currentStep.Identity != nil {
+		return e.visitSlice(p, sliceToVisit)
+	}
+	return nil, pathError(p.currentStep, "filtering lists index with equal not implemented")
+}
+
+func (e eqFilterVisitor) visitMap(p path, mapToVisit map[string]interface{}) (interface{}, error) {
+	if p.currentStep.Number != nil {
+		return nil, pathError(p.currentStep, "failed filtering map: path with index not supported")
+	}
+	interfaceToVisit, ok := mapToVisit[*p.currentStep.Identity]
+	if !ok {
+		return nil, nil
+	}
+	visitResult, err := visitState(p.nextStep(), interfaceToVisit, &e)
+	if err != nil {
+		return nil, err
+	}
+	if visitResult == nil {
+		return nil, nil
+	}
+	filteredMap := map[string]interface{}{}
+	if e.mergeVisitResult {
+		for k, v := range mapToVisit {
+			filteredMap[k] = v
+		}
+	}
+	filteredMap[*p.currentStep.Identity] = visitResult
+	return filteredMap, nil
+}
+
+func (e eqFilterVisitor) visitSlice(p path, sliceToVisit []interface{}) (interface{}, error) {
+	if p.currentStep.Number != nil {
+		return nil, pathError(p.currentStep, "failed filtering slice: path with index not supported")
+	}
+
+	filteredSlice := []interface{}{}
+	hasVisitResult := false
+	for _, interfaceToVisit := range sliceToVisit {
+		// Filter only the first slice by forcing "mergeVisitResult" to true
+		// for the the following ones.
+		visitResult, err := visitState(p, interfaceToVisit, &eqFilterVisitor{mergeVisitResult: true, expectedValue: e.expectedValue})
+		if err != nil {
+			return nil, err
+		}
+		if visitResult != nil {
+			hasVisitResult = true
+			filteredSlice = append(filteredSlice, visitResult)
+		} else if e.mergeVisitResult {
+			filteredSlice = append(filteredSlice, interfaceToVisit)
+		}
+	}
+
+	if !hasVisitResult {
+		return nil, nil
+	}
+	return filteredSlice, nil
 }

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -25,6 +25,11 @@ import (
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
 )
 
+type captureEntryNameAndSteps struct {
+	captureEntryName string
+	steps            ast.VariadicOperator
+}
+
 type Resolver struct{}
 
 type resolver struct {
@@ -204,7 +209,7 @@ func (r *resolver) resolveCaptureEntryPath() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return resolvedPath.walkState(capturedStateEntry)
+	return walk(capturedStateEntry, resolvedPath.steps)
 }
 
 func (r *resolver) resolvePath() (*captureEntryNameAndSteps, error) {

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -502,9 +502,8 @@ default-gw:
          next-hop-interface: eth1
          table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: failed walking non map state " +
-			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]' " +
-			"with path '[routes running badfield]'" + `
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: unexpected non numeric step for slice state " +
+			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.running.badfield.next-hop-interface
 | .....................................................................^`
 
@@ -527,9 +526,8 @@ default-gw:
          next-hop-interface: eth1
          table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: failed walking non slice state " +
-			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]' " +
-			"with path '[routes 1]'" + `
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: unexpected non identity step for map state " +
+			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.1.0.next-hop-interface
 | .............................................................^`
 		runTest(t, &testToRun)
@@ -551,7 +549,7 @@ default-gw:
         next-hop-interface: eth1
         table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: step 'badfield' from path '[routes badfield]' not found at map state " +
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: step not found at map state " +
 			"'map[running:[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.badfield
 | .............................................................^`
@@ -575,7 +573,7 @@ default-gw:
         next-hop-interface: eth1
         table-id: 254
 `
-		testToRun.err = "resolve error: eqfilter error: invalid path: step '6' from path '[routes running 6]' not found at slice state " +
+		testToRun.err = "resolve error: eqfilter error: failed walking path: invalid path: step not found at slice state " +
 			"'[map[destination:0.0.0.0/0 next-hop-address:192.168.100.1 next-hop-interface:eth1 table-id:254]]'" + `
 | routes.running.next-hop-interface==capture.default-gw.routes.running.6
 | .....................................................................^`

--- a/nmpolicy/internal/resolver/visitor.go
+++ b/nmpolicy/internal/resolver/visitor.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+type stateVisitor interface {
+	visitLastMap(path, map[string]interface{}) (interface{}, error)
+	visitLastSlice(path, []interface{}) (interface{}, error)
+	visitMap(path, map[string]interface{}) (interface{}, error)
+	visitSlice(path, []interface{}) (interface{}, error)
+}
+
+func visitState(p path, inputState interface{}, v stateVisitor) (interface{}, error) {
+	originalMap, isMap := inputState.(map[string]interface{})
+	if isMap {
+		if p.hasMoreSteps() {
+			if p.currentStep.Identity == nil {
+				return nil, pathError(p.currentStep, "unexpected non identity step for map state '%+v'", originalMap)
+			}
+			return v.visitMap(p, originalMap)
+		}
+		return v.visitLastMap(p, originalMap)
+	}
+
+	originalSlice, isSlice := inputState.([]interface{})
+	if isSlice {
+		if p.hasMoreSteps() {
+			return v.visitSlice(p, originalSlice)
+		}
+		return v.visitLastSlice(p, originalSlice)
+	}
+	return nil, pathError(p.currentStep, "invalid type %T for identity step '%v'", inputState, *p.currentStep)
+}

--- a/nmpolicy/internal/resolver/walk.go
+++ b/nmpolicy/internal/resolver/walk.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+type captureEntryNameAndSteps struct {
+	captureEntryName string
+	steps            ast.VariadicOperator
+}
+
+func (p captureEntryNameAndSteps) walkState(stateToWalk map[string]interface{}) (interface{}, error) {
+	var (
+		walkedState interface{}
+		walkedPath  []string
+	)
+	walkedState = stateToWalk
+	for _, step := range p.steps {
+		node := step
+		if step.Identity != nil {
+			identityStep := *step.Identity
+			walkedPath = append(walkedPath, identityStep)
+			walkedStateMap, ok := walkedState.(map[string]interface{})
+			if !ok {
+				return nil, wrapWithPathError(&node, fmt.Errorf("failed walking non map state '%+v' with path '%+v'", walkedState, walkedPath))
+			}
+			walkedState, ok = walkedStateMap[identityStep]
+			if !ok {
+				return nil, wrapWithPathError(&node,
+					fmt.Errorf("step '%s' from path '%s' not found at map state '%+v'", identityStep, walkedPath, walkedStateMap))
+			}
+		} else if step.Number != nil {
+			numberStep := *step.Number
+			walkedPath = append(walkedPath, strconv.Itoa(numberStep))
+			walkedStateSlice, ok := walkedState.([]interface{})
+			if !ok {
+				return nil, wrapWithPathError(&node, fmt.Errorf("failed walking non slice state '%+v' with path '%+v'", walkedState, walkedPath))
+			}
+			if len(walkedStateSlice) == 0 || numberStep >= len(walkedStateSlice) {
+				return nil, wrapWithPathError(&node,
+					fmt.Errorf("step '%d' from path '%s' not found at slice state '%+v'", numberStep, walkedPath, walkedStateSlice))
+			}
+			walkedState = walkedStateSlice[numberStep]
+		}
+	}
+	return walkedState, nil
+}


### PR DESCRIPTION
The code that resolves resolve and filter is mixed up at `path.go` so for example the `replace` does not need the `shouldFilter` feature but still the code that runs it has to understand it.

This PR do the following:
- Encapsulate the path advancing into the function `nextStep` and `hasMoreSteps`
- Use a map to decide at what part of the path we should filter entries.
- Create a pair of callbacks for visit a map with an identity and visit a slice when there is no index in the path
- Move the code from filter/replace to their correct place at filter.go and replace.go, implementing previous callbacks.
- Replace the "Fn" visit functions with a `stateVisitor` interface
- Implement path walk using a `pathVisitor`

Closes  https://github.com/nmstate/nmpolicy/issues/83