### PR TITLE
actions: Bump go to 1.17 and use make lint

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,51 +16,47 @@
 
 name: checks
 on: [push, pull_request]
-env:
-  GO_VERSION: 1.16
 jobs:
   lint:
-    name: lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      - uses: arnested/go-version-action@v1
+        id: go-version
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        env:
-          CGO_ENABLED: 0
-        with:
-          version: v1.42.1
+          go-version: ${{ steps.go-version.outputs.minimal }}
+      - name: Run linter
+        run: make lint
   build:
-    name: build
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v2
+    - uses: arnested/go-version-action@v1
+      id: go-version
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ steps.go-version.outputs.minimal }}
     - name: Build cmd
       run: make build
   unit-test:
-    name: unit test 
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v2
+    - uses: arnested/go-version-action@v1
+      id: go-version
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ steps.go-version.outputs.minimal }}
     - name: Run unit tests
       run: make unit-test
   integration-test:
-    name: integration-test
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
@@ -68,7 +64,9 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ steps.go-version.outputs.minimal }}
+    - name: Run unit tests
+      run: make unit-test
     - name: Run tests
       run: make integration-test
   dco:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  GO_VERSION: 1.16
+  GO_VERSION: 1.17
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
@@ -15,10 +15,12 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
+    - uses: arnested/go-version-action@v1
+      id: go-version
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ steps.go-version.outputs.minimal }}
     - name: Build
       run: make -C docs install build
     - name: Publish 🚀

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,18 +9,17 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v2
+      - uses: arnested/go-version-action@v1
+        id: go-version
+      - name: Set up Go
+        uses: actions/setup-go@v1
         with:
-          go-version: 1.16
-      -
-        name: Run GoReleaser
+          go-version: ${{ steps.go-version.outputs.minimal }}
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,18 @@
 module github.com/nmstate/nmpolicy
 
-go 1.16
+go 1.17
 
 require (
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	sigs.k8s.io/yaml v1.3.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -60,10 +60,7 @@ fi
 
 if [ -n "${OPT_LINT}" ]; then
     golangci_lint_version=v1.42.1
-    if [ ! -f $(go env GOPATH)/bin/golangci-lint ]; then
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
-    fi
-    golangci-lint run
+    GOFLAGS=-mod=mod go run github.com/golangci/golangci-lint/cmd/golangci-lint@$golangci_lint_version run
 fi
 
 if [ -n "${OPT_UTEST}" ]; then


### PR DESCRIPTION
The github action to golangci-lint has multiple issues, this change
delegates on the project's "make lint" also su "go run" to run it
instead of installing it for that we need golang 1.17.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>