### PR TITLE
resolver: Filter current state by path

### DIFF
--- a/docs/examples/convert-dhcp-to-static/captured.yaml
+++ b/docs/examples/convert-dhcp-to-static/captured.yaml
@@ -1,0 +1,45 @@
+eth1-iface:
+  metaInfo:
+    time: "2021-12-15T13:45:40Z"
+    version: "0"
+  state:
+    interfaces:
+      - name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          address:
+          - ip: 10.244.0.1
+            prefix-length: 24
+          - ip: 169.254.1.0
+            prefix-length: 16
+          dhcp: true
+          enabled: true
+eth1-routes:
+  metaInfo:
+    time: "2021-12-15T13:45:40Z"
+    version: "0"
+  state:
+    routes:
+      running:
+      - destination: 0.0.0.0/0
+        next-hop-address: 192.168.100.1
+        next-hop-interface: eth1
+        table-id: 254
+      - destination: 1.1.1.0/24
+        next-hop-address: 192.168.100.1
+        next-hop-interface: eth1
+        table-id: 254
+dns:
+  metaInfo:
+    time: "2021-12-15T13:45:40Z"
+    version: "0"
+  state:
+    dns-resolver:
+      running:
+        search:
+        - example.com
+        - example.org
+        server:
+        - 8.8.8.8
+        - 2001:4860:4860::8888

--- a/docs/examples/convert-dhcp-to-static/current.yaml
+++ b/docs/examples/convert-dhcp-to-static/current.yaml
@@ -1,0 +1,30 @@
+dns-resolver:
+  running:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 8.8.8.8
+    - 2001:4860:4860::8888
+routes:
+  running:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+  - destination: 1.1.1.0/24
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: 10.244.0.1
+      prefix-length: 24
+    - ip: 169.254.1.0
+      prefix-length: 16
+    dhcp: true
+    enabled: true

--- a/docs/examples/convert-dhcp-to-static/generated.yaml
+++ b/docs/examples/convert-dhcp-to-static/generated.yaml
@@ -1,0 +1,30 @@
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 8.8.8.8
+    - 2001:4860:4860::8888
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+  - destination: 1.1.1.0/24
+    next-hop-address: 192.168.100.1
+    next-hop-interface: eth1
+    table-id: 254
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: 10.244.0.1
+      prefix-length: 24
+    - ip: 169.254.1.0
+      prefix-length: 16
+    dhcp: false
+    enabled: true

--- a/docs/examples/convert-dhcp-to-static/policy.md
+++ b/docs/examples/convert-dhcp-to-static/policy.md
@@ -1,0 +1,19 @@
+{% raw %}
+capture:
+  eth1-iface: interfaces.name == "eth1"
+  eth1-routes: routes.running.next-hop-interface == "eth1"
+  dns: dns-resolver.running
+desiredState:
+  interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address: "{{ capture.eth1-iface.interfaces.0.ipv4.address }}"
+      dhcp: false
+      enabled: true
+  routes:
+    config: "{{ capture.eth1-routes.routes.running }}"
+  dns-resolver:
+    config: "{{ capture.dns.dns-resolver.running }}"
+{% endraw %}

--- a/docs/user-guide/102-policy-syntax.md
+++ b/docs/user-guide/102-policy-syntax.md
@@ -46,7 +46,8 @@ The following is a semi-formal definition of the capture entry expression:
 <eqexpression> ::= <path> <eqoperator> (<string> | <number> | <capturepath>)
 <replaceoperator> ::= ":="
 <replaceexpression> ::= <path> <replaceoperator> (<string> | <number> | <capturepath>)
-<expression> ::= <eqexpression> | <replaceexpression>
+<pathexpression> ::= <path>
+<expression> ::= <pathexpression> | <eqexpression> | <replaceexpression>
 <pipe> ::= "|"
 <pipedexpression> ::= <capturepath> <pipe> <expression>
 ```
@@ -76,6 +77,30 @@ interfaces.name == "eth1"
 routes.destination == "0.0.0.0/0"
 dns.server == "192.168.1.1"
 interfaces.name == capture.default-gw.interfaces.0.name
+```
+
+### Path filter ```<pathexpression>```
+Filter out current state to include only the data matching the ```<path>```
+
+Following is a path filter to filter out everything except the running DNS
+configuration:
+```
+dns-resolver.running
+```
+
+This will create a capture entry with the the following Nmstate
+```yaml
+dns-resolver:
+  running:
+    search:
+    - redhat.com
+    server:
+    - 8.8.8.8
+```
+
+This can be referened later on with:
+```
+"{{ capture.[capture name].dns-resolver.running }}"
 ```
 
 ### Replace ```<replaceexpression>```

--- a/nmpolicy/internal/resolver/resolver.go
+++ b/nmpolicy/internal/resolver/resolver.go
@@ -116,6 +116,8 @@ func (r *resolver) resolveCaptureASTEntry() (types.NMState, error) {
 		return r.resolveEqFilter()
 	} else if r.currentNode.Replace != nil {
 		return r.resolveReplace()
+	} else if r.currentNode.Path != nil {
+		return r.resolvePathFilter()
 	}
 	return nil, fmt.Errorf("root node has unsupported operation : %s", *r.currentNode)
 }
@@ -136,6 +138,10 @@ func (r *resolver) resolveReplace() (types.NMState, error) {
 		return nil, wrapWithResolveError(err)
 	}
 	return replacedState, nil
+}
+
+func (r *resolver) resolvePathFilter() (types.NMState, error) {
+	return filter(r.currentState, *r.currentNode.Path, nil)
 }
 
 func (r *resolver) resolveTernaryOperator(operator *ast.TernaryOperator,

--- a/nmpolicy/internal/resolver/resolver_test.go
+++ b/nmpolicy/internal/resolver/resolver_test.go
@@ -135,6 +135,7 @@ func TestFilter(t *testing.T) {
 		testFilterDifferentTypeOnPath(t)
 		testFilterOptionalField(t)
 		testFilterNonCaptureRefPathAtThirdArg(t)
+		testFilterByPath(t)
 		testFilterWithInvalidInputSource(t)
 		testFilterWithInvalidTypeInSource(t)
 		testFilterBadPath(t)
@@ -919,6 +920,33 @@ description-eth2:
       type: ethernet
       state: down
 `}
+		runTest(t, &testToRun)
+	})
+}
+
+func testFilterByPath(t *testing.T) {
+	t.Run("filter current state by path", func(t *testing.T) {
+		testToRun := withCaptureExpressions(t, `
+running-routes: routes.running
+`)
+		testToRun.expectedCapturedStates = `
+running-routes:
+  state:
+    routes:
+      running:
+      - destination: 0.0.0.0/0
+        next-hop-address: 192.168.100.1
+        next-hop-interface: eth1
+        table-id: 254
+      - destination: 1.1.1.0/24
+        next-hop-address: 192.168.100.1
+        next-hop-interface: eth1
+        table-id: 254
+      - destination: 2.2.2.0/24
+        next-hop-address: 192.168.200.1
+        next-hop-interface: eth2
+        table-id: 254
+`
 		runTest(t, &testToRun)
 	})
 }


### PR DESCRIPTION
Sometime is needed for a capture to reference just a part of current
state without comparing any value. This change add the possibility to
pass a path to a capture and return a Nmstate with data at that path.

This allow policies like the following:

```yaml
capture:
  eth1-iface: interfaces.name == "eth1"
  eth1-routes: routes.running.next-hop-interface == "eth1"
  dns: dns-resolver.running
desiredState:
  interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      address: "{{ capture.eth1-iface.interfaces.0.ipv4.address }}"
      dhcp: false
      enabled: true
  routes:
    config: "{{ capture.eth1-routes.running }}"
  dns-resolver:
    config: "{{ capture.dns.dns-resolver.running }}"
```

Signed-off-by: Enrique Llorente <ellorent@redhat.com>