### PR TITLE
docs: Fix path filter docs

### DIFF
--- a/docs/user-guide/102-policy-syntax.md
+++ b/docs/user-guide/102-policy-syntax.md
@@ -99,8 +99,11 @@ dns-resolver:
 ```
 
 This can be referened later on with:
+
 ```
+{% raw %}
 "{{ capture.[capture name].dns-resolver.running }}"
+{% endraw %}
 ```
 
 ### Replace ```<replaceexpression>```


### PR DESCRIPTION
The path filter contains problematic syntax on the docs.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>