### PR TITLE
replace: Fix issue with setting value to a sub-key, that doesn't exist

### DIFF
--- a/nmpolicy/internal/resolver/constructor.go
+++ b/nmpolicy/internal/resolver/constructor.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import "fmt"
+
+func constructState(p path, inputState, prevStep interface{}) (interface{}, error) {
+	var err error
+	identity, isString := prevStep.(*string)
+	if isString {
+		originalMap, isMap := inputState.(map[string]interface{})
+		if isMap {
+			if p.hasMoreSteps() {
+				originalMap[*identity] = map[string]interface{}{}
+				originalMap[*identity], err = constructState(p.nextStepByRef(), originalMap[*identity], p.currentStep.Identity)
+				if err != nil {
+					return nil, fmt.Errorf("failed to construct missing path in inputState '%+v', error: %s", inputState, err.Error())
+				}
+				return originalMap, nil
+			} else {
+				var i interface{}
+				originalMap[*identity] = i
+				return originalMap, nil
+			}
+		} else {
+			return nil, fmt.Errorf("only a map structure can be constructed, got %T", inputState)
+		}
+	} else {
+		return nil, fmt.Errorf("constructState only supports string map keys, got '%+v", identity)
+	}
+}

--- a/nmpolicy/internal/resolver/path.go
+++ b/nmpolicy/internal/resolver/path.go
@@ -45,3 +45,15 @@ func (p path) nextStep() path {
 func (p path) hasMoreSteps() bool {
 	return p.currentStepIndex+1 < len(p.steps)
 }
+
+func (p *path) nextStepByRef() path {
+	if p.hasMoreSteps() {
+		p.currentStepIndex++
+	}
+	p.currentStep = &p.steps[p.currentStepIndex]
+	return *p
+}
+
+func (p *path) getRemainingSteps() []ast.Node {
+	return p.steps[p.currentStepIndex:]
+}

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -17,6 +17,8 @@
 package resolver
 
 import (
+	"fmt"
+
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
 )
 
@@ -61,7 +63,18 @@ func (r replaceOpVisitor) visitMap(p path, mapToVisit map[string]interface{}) (i
 	}
 	interfaceToVisit, ok := mapToVisit[*p.currentStep.Identity]
 	if !ok {
-		return nil, nil
+		newSteps, err := constructState(newPath(p.getRemainingSteps()), mapToVisit, p.currentStep.Identity)
+		if err != nil {
+			return nil, err
+		}
+		mapToVisit, ok = newSteps.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failed to convert constructed steps back to a map")
+		}
+		interfaceToVisit, ok = mapToVisit[*p.currentStep.Identity]
+		if !ok {
+			return nil, fmt.Errorf("failed access the just added map key")
+		}
 	}
 
 	visitResult, err := visitState(p.nextStep(), interfaceToVisit, &r)


### PR DESCRIPTION
This commit constructs map key according to a path given to replace
operator, so that replace may set a value to a sub-key, that doesn't
exist in the original state.

For an example, consider the following state:
```yaml
state:
  interfaces:
  - name: eth0
    type: ethernet
```

If we attempt to use replace to set interfaces.lldp.enabled:=true, the
following result is expected with the chanes in this PR:
```yaml
state:
  interfaces:
  - name: eth0
    type: ethernet
    lldp:
      enabled: true
```
Without constructing the map structure, replace returned nil.
Only maps are constructed in thie fashion, replace in a missing slice
remains unsupported.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>