### PR TITLE
replace: Return map if missing path

### DIFF
--- a/docs/examples/all-ethernet-up/captured.yaml
+++ b/docs/examples/all-ethernet-up/captured.yaml
@@ -1,0 +1,46 @@
+ethernets:
+  metaInfo:
+    time: "2021-12-15T13:45:40Z"
+    version: "0"
+  state:
+    interfaces:
+    - accept-all-mac-addresses: false
+      lldp:
+        enabled: false
+      mac-address: 52:55:00:D1:55:02
+      name: eth0
+      state: up
+      type: ethernet
+    - accept-all-mac-addresses: false
+      lldp:
+        enabled: false
+      mac-address: 52:55:00:D1:56:02
+      name: eth1
+      state: down
+      type: ethernet
+ethernets-up:
+  metaInfo:
+    time: "2021-12-15T13:45:40Z"
+    version: "0"
+  state:
+    interfaces:
+    - accept-all-mac-addresses: false
+      lldp:
+        enabled: false
+      mac-address: 52:55:00:D1:55:02
+      name: eth0
+      state: up
+      type: ethernet
+ethernets-lldp:
+  metaInfo:
+    time: "2021-12-15T13:45:40Z"
+    version: "0"
+  state:
+    interfaces:
+    - accept-all-mac-addresses: false
+      lldp:
+        enabled: false
+      mac-address: 52:55:00:D1:55:02
+      name: eth0
+      state: up
+      type: ethernet

--- a/docs/examples/all-ethernet-up/captured.yaml
+++ b/docs/examples/all-ethernet-up/captured.yaml
@@ -7,7 +7,7 @@ ethernets:
     - accept-all-mac-addresses: false
       lldp:
         enabled: false
-      mac-address: 52:55:00:D1:55:02
+      mac-address: 52:55:00:D1:55:01
       name: eth0
       state: up
       type: ethernet
@@ -16,6 +16,16 @@ ethernets:
         enabled: false
       mac-address: 52:55:00:D1:56:02
       name: eth1
+      state: down
+      type: ethernet
+    - accept-all-mac-addresses: false
+      mac-address: 52:55:00:D1:57:03
+      name: eth4
+      state: up
+      type: ethernet
+    - accept-all-mac-addresses: false
+      mac-address: 52:55:00:D1:56:04
+      name: eth2
       state: down
       type: ethernet
 ethernets-up:
@@ -27,8 +37,13 @@ ethernets-up:
     - accept-all-mac-addresses: false
       lldp:
         enabled: false
-      mac-address: 52:55:00:D1:55:02
+      mac-address: 52:55:00:D1:55:01
       name: eth0
+      state: up
+      type: ethernet
+    - accept-all-mac-addresses: false
+      mac-address: 52:55:00:D1:57:03
+      name: eth4
       state: up
       type: ethernet
 ethernets-lldp:
@@ -39,8 +54,15 @@ ethernets-lldp:
     interfaces:
     - accept-all-mac-addresses: false
       lldp:
-        enabled: false
-      mac-address: 52:55:00:D1:55:02
+        enabled: true
+      mac-address: 52:55:00:D1:55:01
       name: eth0
+      state: up
+      type: ethernet
+    - accept-all-mac-addresses: false
+      lldp:
+        enabled: true
+      mac-address: 52:55:00:D1:57:03
+      name: eth4
       state: up
       type: ethernet

--- a/docs/examples/all-ethernet-up/current.yaml
+++ b/docs/examples/all-ethernet-up/current.yaml
@@ -2,7 +2,7 @@ interfaces:
 - accept-all-mac-addresses: false
   lldp:
     enabled: false
-  mac-address: 52:55:00:D1:55:02
+  mac-address: 52:55:00:D1:55:01
   name: eth0
   state: up
   type: ethernet
@@ -13,3 +13,14 @@ interfaces:
   name: eth1
   state: down
   type: ethernet
+- accept-all-mac-addresses: false
+  mac-address: 52:55:00:D1:57:03
+  name: eth4
+  state: up
+  type: ethernet
+- accept-all-mac-addresses: false
+  mac-address: 52:55:00:D1:56:04
+  name: eth2
+  state: down
+  type: ethernet
+

--- a/docs/examples/all-ethernet-up/current.yaml
+++ b/docs/examples/all-ethernet-up/current.yaml
@@ -1,0 +1,15 @@
+interfaces:
+- accept-all-mac-addresses: false
+  lldp:
+    enabled: false
+  mac-address: 52:55:00:D1:55:02
+  name: eth0
+  state: up
+  type: ethernet
+- accept-all-mac-addresses: false
+  lldp:
+    enabled: false
+  mac-address: 52:55:00:D1:56:02
+  name: eth1
+  state: down
+  type: ethernet

--- a/docs/examples/all-ethernet-up/generated.yaml
+++ b/docs/examples/all-ethernet-up/generated.yaml
@@ -1,0 +1,8 @@
+interfaces:
+- accept-all-mac-addresses: false
+  lldp:
+    enabled: true
+  mac-address: 52:55:00:D1:55:02
+  name: eth0
+  state: up
+  type: ethernet

--- a/docs/examples/all-ethernet-up/generated.yaml
+++ b/docs/examples/all-ethernet-up/generated.yaml
@@ -2,7 +2,14 @@ interfaces:
 - accept-all-mac-addresses: false
   lldp:
     enabled: true
-  mac-address: 52:55:00:D1:55:02
+  mac-address: 52:55:00:D1:55:01
   name: eth0
+  state: up
+  type: ethernet
+- accept-all-mac-addresses: false
+  lldp:
+    enabled: true
+  mac-address: 52:55:00:D1:57:03
+  name: eth4
   state: up
   type: ethernet

--- a/docs/examples/all-ethernet-up/policy.md
+++ b/docs/examples/all-ethernet-up/policy.md
@@ -1,0 +1,9 @@
+{% raw %}
+capture:
+  ethernets: interfaces.type=="ethernet"
+  ethernets-up: capture.ethernets.interfaces.state=="up"
+  ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=true
+
+desiredState: 
+  interfaces: "{{ capture.ethernets-lldp.interfaces }}"
+{% endraw %}

--- a/nmpolicy/internal/resolver/replace.go
+++ b/nmpolicy/internal/resolver/replace.go
@@ -61,7 +61,7 @@ func (r replaceOpVisitor) visitMap(p path, mapToVisit map[string]interface{}) (i
 	}
 	interfaceToVisit, ok := mapToVisit[*p.currentStep.Identity]
 	if !ok {
-		return nil, nil
+		interfaceToVisit = map[string]interface{}{}
 	}
 
 	visitResult, err := visitState(p.nextStep(), interfaceToVisit, &r)

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -105,7 +105,8 @@ func TestExamples(t *testing.T) {
 			assert.NoError(t, err)
 			obtainedCaptuerdStates, err := formatCapturedStates(obtained.Cache.Capture)
 			assert.NoError(t, err)
-			assert.Equal(t, resetCapturedStatesTimeStamp(expectedCapturedStates), resetCapturedStatesTimeStamp(obtainedCaptuerdStates))
+			assert.YAMLEq(t, marshalCapturedStates(t, resetCapturedStatesTimeStamp(expectedCapturedStates)),
+				marshalCapturedStates(t, resetCapturedStatesTimeStamp(obtainedCaptuerdStates)))
 		})
 	}
 }
@@ -126,4 +127,10 @@ func formatCapturedStates(capturedStates map[string]types.CaptureState) (map[str
 		capturedStates[captureID] = captureState
 	}
 	return capturedStates, nil
+}
+
+func marshalCapturedStates(t *testing.T, capturedStates map[string]types.CaptureState) string {
+	marshaledBytes, err := yaml.Marshal(capturedStates)
+	assert.NoError(t, err)
+	return string(marshaledBytes)
 }


### PR DESCRIPTION
When the replace expression is referencing a missing path nmpolicy was failing since it cannot find the keys in the state. This PR create new empty dictionaries to fill in the gaps from the replace expression.